### PR TITLE
feat: editorial-luxe homepage redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=Inter+Tight:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/src/components/ConsultingHero.tsx
+++ b/src/components/ConsultingHero.tsx
@@ -1,45 +1,90 @@
 import { Link } from 'react-router-dom';
+import { Reveal } from './Reveal';
+import { CountUp } from './CountUp';
+
+function ArrowRight() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}
 
 export function ConsultingHero() {
   return (
-    <section className="relative min-h-[70vh] flex items-center bg-grid">
-      <div className="container max-w-6xl section-padding">
-        <div className="max-w-4xl">
-          {/* Main heading */}
-          <h1 className="text-hero font-mono font-bold text-foreground mb-6 animate-fade-in-2">
-            AI Transformation Leadership, Embedded
-          </h1>
+    <section className="hero" id="top">
+      <svg className="hero__glyph" viewBox="0 0 600 600" aria-hidden="true">
+        <defs>
+          <linearGradient id="gGlyph" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stopColor="var(--brand)" stopOpacity="0.9" />
+            <stop offset="1" stopColor="var(--fg)" stopOpacity="0.3" />
+          </linearGradient>
+        </defs>
+        <circle cx="300" cy="300" r="260" fill="none" stroke="url(#gGlyph)" strokeWidth="1.2" />
+        <circle cx="300" cy="300" r="180" fill="none" stroke="var(--fg)" strokeWidth="0.8" opacity="0.45" />
+        <circle cx="300" cy="300" r="100" fill="none" stroke="var(--fg)" strokeWidth="0.8" opacity="0.6" />
+        <line x1="40" y1="300" x2="560" y2="300" stroke="var(--fg)" strokeWidth="0.5" opacity="0.3" />
+        <line x1="300" y1="40" x2="300" y2="560" stroke="var(--fg)" strokeWidth="0.5" opacity="0.3" />
+      </svg>
 
-          {/* Subhead */}
-          <p className="font-mono text-xl md:text-2xl text-muted-foreground mb-8 animate-fade-in-3">
-            I serve as Fractional CTO & AI Transformation Officer for organizations
-            navigating the shift from AI experimentation to AI operations<span className="cursor-blink"></span>
-          </p>
+      <div className="shell">
+        <Reveal className="hero__meta">
+          <span className="eyebrow" style={{ display: 'inline-flex', alignItems: 'center', gap: '0.55rem' }}>
+            <span className="dot" aria-hidden="true" />
+            Taking 2–3 clients, 2026
+          </span>
+          <span className="eyebrow">Est. 2024 &nbsp;·&nbsp; Coastal VA</span>
+        </Reveal>
 
-          {/* Description */}
-          <p className="text-lg text-muted-foreground leading-relaxed mb-10 max-w-2xl animate-fade-in-4">
-            Strategy, governance, architecture, and implementation. I connect
-            executive vision to engineering execution, then train your team to own it.
-          </p>
+        <Reveal delay={1} as="h1" className="t-hero hero__title">
+          AI Transformation Leadership,{' '}
+          <span className="brand-accent">Embedded</span>
+        </Reveal>
 
-          {/* CTA */}
-          <div className="flex flex-wrap gap-4 animate-fade-in-4">
-            <Link to="/contact" className="btn-primary">
-              [Book a Discovery Call]
-            </Link>
-            <a href="#proof" className="btn-ghost">
-              See Proof Points {'>'}
-            </a>
+        <Reveal delay={2} className="hero__sub">
+          <div>
+            <p className="t-lead t-muted-new">
+              I serve as Fractional CTO &amp; AI Transformation Officer for organizations
+              navigating the shift from AI experimentation to AI operations. Strategy,
+              governance, architecture, and implementation — I connect executive vision
+              to engineering execution, then train your team to own it.
+            </p>
+            <div className="hero__ctas" style={{ marginTop: '1.75rem' }}>
+              <Link className="btn" to="/contact">
+                Book a discovery call <ArrowRight />
+              </Link>
+              <Link className="btn btn--ghost" to="/services">
+                See services
+              </Link>
+            </div>
           </div>
-        </div>
-      </div>
-
-      {/* Decorative corner elements */}
-      <div className="absolute bottom-8 right-8 font-mono text-xs text-muted-foreground/30 hidden lg:block">
-        <div>┌──────────────────────────┐</div>
-        <div>│ AI TRANSFORMATION        │</div>
-        <div>│ EMBEDDED ADVISORY        │</div>
-        <div>└──────────────────────────┘</div>
+          <div className="hero__stats">
+            <div className="hero__stat">
+              <span className="n">
+                20+ <span style={{ fontSize: '0.6em', fontFamily: 'var(--font-mono-new)', color: 'var(--fg-muted)' }}>yrs</span>
+              </span>
+              <span className="l">Tech leadership</span>
+            </div>
+            <div className="hero__stat">
+              <span className="n">
+                $<CountUp to={35} format={(n) => Math.round(n).toString()} />M+
+              </span>
+              <span className="l">Managed portfolios</span>
+            </div>
+            <div className="hero__stat">
+              <span className="n">
+                $<CountUp to={9} format={(n) => Math.round(n).toString()} />M+
+              </span>
+              <span className="l">New business won</span>
+            </div>
+            <div className="hero__stat">
+              <span className="n">
+                <CountUp to={23} format={(n) => Math.round(n).toString()} />K+
+              </span>
+              <span className="l">Newsletter subscribers</span>
+            </div>
+          </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/src/components/ConsultingHero.tsx
+++ b/src/components/ConsultingHero.tsx
@@ -1,14 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
 import { CountUp } from './CountUp';
-
-function ArrowRight() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
-    </svg>
-  );
-}
+import { ArrowRight } from './Icons';
 
 export function ConsultingHero() {
   return (

--- a/src/components/CountUp.tsx
+++ b/src/components/CountUp.tsx
@@ -19,6 +19,10 @@ export function CountUp({ to, duration = 1600, format = (n) => n.toLocaleString(
         entries.forEach((e) => {
           if (e.isIntersecting && !started) {
             setStarted(true);
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+              setVal(to);
+              return;
+            }
             const start = performance.now();
             const tick = (now: number) => {
               const t = Math.min(1, (now - start) / duration);

--- a/src/components/CountUp.tsx
+++ b/src/components/CountUp.tsx
@@ -1,0 +1,41 @@
+import { useRef, useEffect, useState } from 'react';
+
+interface CountUpProps {
+  to: number;
+  duration?: number;
+  format?: (n: number) => string;
+}
+
+export function CountUp({ to, duration = 1600, format = (n) => n.toLocaleString() }: CountUpProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [val, setVal] = useState(0);
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting && !started) {
+            setStarted(true);
+            const start = performance.now();
+            const tick = (now: number) => {
+              const t = Math.min(1, (now - start) / duration);
+              const eased = 1 - Math.pow(1 - t, 4);
+              setVal(to * eased);
+              if (t < 1) requestAnimationFrame(tick);
+              else setVal(to);
+            };
+            requestAnimationFrame(tick);
+          }
+        });
+      },
+      { threshold: 0.3 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [to, duration, started]);
+
+  return <span ref={ref}>{format(val)}</span>;
+}

--- a/src/components/CredentialsBanner.tsx
+++ b/src/components/CredentialsBanner.tsx
@@ -1,113 +1,60 @@
 import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
 
+const TAGS = [
+  'MS Tech Management · GMU',
+  'BS Computer Science · Bowie State',
+  'PMP',
+  'Lean Six Sigma Green Belt',
+  'Certified Scrum Master',
+  'GMU Alumni Board',
+  'NIST AI RMF',
+  'Responsible AI',
+];
+
 export function CredentialsBanner() {
   return (
-    <section className="section-padding section-accent">
-      <div className="container max-w-6xl">
-        {/* Section header */}
+    <section className="section bg-section" id="background">
+      <div className="shell bg-section__inner">
         <Reveal>
-          <div className="mb-12">
-            <h2 className="font-mono text-sm text-muted-foreground mb-2">
-              // CREDENTIALS
-            </h2>
-          </div>
+          <span className="eyebrow">04 — Background</span>
+          <h2 className="t-display" style={{ marginTop: '1.5rem', maxWidth: '16ch' }}>
+            Two decades. One{' '}
+            <em style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>operating system.</em>
+          </h2>
+          <p
+            className="t-mono-sm t-muted-new"
+            style={{ marginTop: '2rem', maxWidth: '30ch' }}
+          >
+            Engineer's mind, artist's soul.
+            <br />
+            Consulting rigor, founder instincts.
+          </p>
         </Reveal>
 
-        {/* Credentials grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          <Reveal delay={1}>
-            <div className="border border-border bg-card p-6 h-full">
-              <h3 className="font-mono text-base font-semibold text-foreground mb-3">
-                Experience
-              </h3>
-              <p className="text-metric-display text-foreground font-semibold mb-2">
-                20+ years in enterprise technology
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Federal Reserve, Booz Allen Hamilton, Pariveda Solutions, Beyondsoft/TPG, SAIC
-              </p>
-              <p className="text-xs text-muted-foreground/70 mt-1">
-                Clients include Toyota/Lexus, NFL, OMERS, TaxAct, Daylight Transport, Stop Soldier Suicide
-              </p>
-            </div>
-          </Reveal>
-
-          <Reveal delay={2}>
-            <div className="border border-border bg-card p-6 h-full">
-              <h3 className="font-mono text-base font-semibold text-foreground mb-3">
-                Impact
-              </h3>
-              <p className="text-metric-display text-foreground font-semibold mb-2">
-                $35M+ in managed portfolios
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                $9M+ in new business won
-              </p>
-            </div>
-          </Reveal>
-
-          <Reveal delay={3}>
-            <div className="border border-border bg-card p-6 h-full">
-              <h3 className="font-mono text-base font-semibold text-foreground mb-3">
-                Roles
-              </h3>
-              <p className="text-metric-display text-foreground font-semibold mb-2">
-                Founder & AI Transformation Officer
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Board advisor, George Mason University
-              </p>
-            </div>
-          </Reveal>
-
-          <Reveal delay={3}>
-            <div className="border border-border bg-card p-6 h-full">
-              <h3 className="font-mono text-base font-semibold text-foreground mb-3">
-                Distribution
-              </h3>
-              <p className="text-metric-display text-foreground font-semibold mb-2">
-                17,000+ subscribers
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Claude Code for Non-Coders — AI transformation thinking at scale
-              </p>
-            </div>
-          </Reveal>
-
-          <Reveal delay={4}>
-            <div className="border border-border bg-card p-6 h-full">
-              <h3 className="font-mono text-base font-semibold text-foreground mb-3">
-                Governance
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                NIST AI RMF · Responsible AI · Algorithmic Impact Assessment · AI Operating Model Design
-              </p>
-            </div>
-          </Reveal>
-        </div>
-
-        {/* Scale note */}
-        <Reveal>
-          <div className="mt-8 text-center border border-border bg-card p-4">
-            <p className="text-sm text-muted-foreground">
-              I take on 2–3 embedded engagements at a time. Let's see if there's a fit.{' '}
-              <Link to="/services" className="font-mono text-terminal-cyan hover:underline">
-                See services →
-              </Link>
+        <Reveal delay={2}>
+          <div className="bg-section__prose">
+            <p>
+              20+ years leading technology initiatives at Booz Allen Hamilton, Pariveda
+              Solutions, and enterprise clients including Toyota/Lexus, NFL, OMERS,
+              Federal Reserve Board, and TaxAct.
+            </p>
+            <p>
+              I've won <span className="brand-accent">$9M+</span> in new business,
+              built and led consulting practices generating $6M+ annually, and
+              shipped solutions across financial services, transportation, healthcare,
+              nonprofit, and media.
             </p>
           </div>
-        </Reveal>
-
-        {/* Lab cross-link */}
-        <Reveal>
-          <div className="mt-4 text-center">
-            <p className="text-sm text-muted-foreground">
-              See what I'm building.{' '}
-              <Link to="/lab" className="font-mono text-terminal-cyan hover:underline">
-                Visit the Lab →
-              </Link>
-            </p>
+          <div className="credentials-tags">
+            {TAGS.map((t) => (
+              <span key={t} className="credentials-tag">{t}</span>
+            ))}
+          </div>
+          <div style={{ marginTop: '2rem' }}>
+            <Link to="/about" className="btn btn--ghost" style={{ display: 'inline-flex' }}>
+              Full background →
+            </Link>
           </div>
         </Reveal>
       </div>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,9 +1,11 @@
 import { ConsultingHero } from './ConsultingHero';
+import { MarqueeStrip } from './Marquee';
 import { ProblemSection } from './ProblemSection';
 import { WhatIDo } from './WhatIDo';
 import { ProofSection } from './ProofSection';
 import { CredentialsBanner } from './CredentialsBanner';
 import { HowItWorks } from './HowItWorks';
+import { WritingSection } from './WritingSection';
 import { WorkWithMe } from './WorkWithMe';
 import { SEO } from './SEO';
 
@@ -15,15 +17,15 @@ export default function Home() {
         description="AI transformation leadership, embedded. I help companies move from AI experiments to AI results. Strategy, governance, architecture, and implementation."
         url="/"
       />
-      <main className="bg-background text-foreground w-full overflow-x-hidden">
-        <ConsultingHero />
-        <ProblemSection />
-        <WhatIDo />
-        <ProofSection />
-        <CredentialsBanner />
-        <HowItWorks />
-        <WorkWithMe />
-      </main>
+      <ConsultingHero />
+      <MarqueeStrip />
+      <ProblemSection />
+      <WhatIDo />
+      <ProofSection />
+      <CredentialsBanner />
+      <HowItWorks />
+      <WritingSection />
+      <WorkWithMe />
     </>
   );
 }

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -1,57 +1,52 @@
 import { Reveal } from './Reveal';
 
+const STEPS = [
+  {
+    n: '01',
+    badge: '30 min · free',
+    title: <>Discovery <em>call</em></>,
+    desc: "You tell me what's stuck. I tell you if I can help. No deck, no pitch — just a direct read on fit.",
+    note: '→ Low friction by design',
+  },
+  {
+    n: '02',
+    badge: 'Paid engagement',
+    title: <>Scoping <em>session</em></>,
+    desc: "We map the problem, define success metrics, and build a work plan. You get a document you could hand to any implementer.",
+    note: '→ Value on day one',
+  },
+  {
+    n: '03',
+    badge: 'Execution',
+    title: <>Build, ship, <em>enable</em></>,
+    desc: "I build. You ship. Your team learns. The engagement ends when something is live, measured, and owned internally.",
+    note: '→ No lock-in, ever',
+  },
+];
+
 export function HowItWorks() {
   return (
-    <section className="section-padding">
-      <div className="container max-w-4xl">
-        <Reveal>
-          <h2 className="font-mono text-sm text-muted-foreground mb-8">
-            // HOW_IT_WORKS
-          </h2>
-        </Reveal>
-
-        <div className="space-y-8">
-          <Reveal delay={1}>
-            <div className="flex gap-6">
-              <div className="font-mono text-4xl md:text-5xl text-terminal-cyan font-bold">01</div>
-              <div>
-                <h3 className="font-mono text-lg font-semibold mb-2">
-                  Discovery Call (30 min, free)
-                </h3>
-                <p className="text-muted-foreground">
-                  You tell me what's stuck. I tell you if I can help.
-                </p>
-              </div>
-            </div>
+    <section className="section rule-top" id="how">
+      <div className="shell">
+        <div className="what__intro">
+          <Reveal>
+            <span className="eyebrow">05 — How it works</span>
+            <h2 className="t-display" style={{ marginTop: '1.5rem', maxWidth: '20ch' }}>
+              Three steps. No mystery.
+            </h2>
           </Reveal>
+        </div>
 
-          <Reveal delay={2}>
-            <div className="flex gap-6">
-              <div className="font-mono text-4xl md:text-5xl text-terminal-cyan font-bold">02</div>
-              <div>
-                <h3 className="font-mono text-lg font-semibold mb-2">
-                  Scoping Session
-                </h3>
-                <p className="text-muted-foreground">
-                  We map the problem, define success metrics, and build a work plan.
-                </p>
-              </div>
-            </div>
-          </Reveal>
-
-          <Reveal delay={3}>
-            <div className="flex gap-6">
-              <div className="font-mono text-4xl md:text-5xl text-terminal-cyan font-bold">03</div>
-              <div>
-                <h3 className="font-mono text-lg font-semibold mb-2">
-                  Execution
-                </h3>
-                <p className="text-muted-foreground">
-                  I embed, build, and transfer. Your team ships. Your organization learns.
-                </p>
-              </div>
-            </div>
-          </Reveal>
+        <div className="steps">
+          {STEPS.map((s, i) => (
+            <Reveal key={s.n} delay={(i + 1) as 1 | 2 | 3} className="step">
+              <span className="step__num">{s.n}</span>
+              <span className="step__badge">{s.badge}</span>
+              <h3 className="step__title">{s.title}</h3>
+              <p className="step__desc">{s.desc}</p>
+              <span className="step__note">{s.note}</span>
+            </Reveal>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,0 +1,15 @@
+export function ArrowRight() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}
+
+export function ArrowUpRight({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M5 11L11 5M6 5h5v5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -83,7 +83,7 @@ export default function Insights() {
               <Reveal delay={1}>
                 <div className="border border-terminal-cyan/30 bg-terminal-cyan/5 p-8 hover:border-terminal-cyan/50 transition-colors h-full flex flex-col">
                   <div className="font-mono text-xs text-terminal-cyan mb-4">
-                    [WEEKLY] · 17,000+ subscribers
+                    [WEEKLY] · 23,000+ subscribers
                   </div>
                   <h3 className="font-mono text-xl font-semibold mb-4">
                     Claude Code for Non-Coders

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -138,7 +138,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col w-full overflow-x-hidden" style={{ background: "var(--bg)", color: "var(--fg)" }}>
       <Nav />
-      <main className="flex-1 w-full overflow-x-hidden" style={{ paddingTop: "3.5rem" }}>
+      <main className="flex-1 w-full overflow-x-hidden" style={{ paddingTop: "var(--nav-h)" }}>
         {children}
       </main>
       <Footer />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,102 +1,116 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import Lenis from "lenis";
-import { ThemeToggle } from "./ThemeToggle";
+import { useTheme } from "./ThemeProvider";
 import { MobileMenu } from "./MobileMenu";
-import { Logo } from "./Logo";
 
-function Header() {
+function SunIcon() {
   return (
-    <header
-      className="sticky top-0 z-40 w-full border-b border-border bg-background/90 backdrop-blur-sm"
-      role="banner"
-      aria-label="Site Header"
-    >
-      <div className="container mx-auto px-4 flex h-14 items-center justify-between">
-        {/* Logo */}
-        <Link
-          to="/"
-          className="text-foreground hover:text-terminal-cyan transition-colors"
-          aria-label="D. E. Williams + Co. Home"
-        >
-          <Logo />
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function Nav() {
+  const { theme, toggleTheme } = useTheme();
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 12);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <nav className="nav" data-scrolled={scrolled ? "true" : "false"} aria-label="Primary">
+      <div className="shell nav__inner">
+        <Link to="/" className="nav__brand" aria-label="D. E. Williams + Co., home">
+          <span>D. E. Williams</span>
+          <span className="mark">+</span>
+          <span>Co.</span>
         </Link>
 
-        {/* Desktop navigation */}
-        <nav
-          className="hidden md:flex items-center gap-1"
-          role="navigation"
-          aria-label="Main Navigation"
-        >
-          <Link to="/" className="nav-link">home</Link>
-          <Link to="/services" className="nav-link">services</Link>
-          <Link to="/about" className="nav-link">about</Link>
-          <Link to="/insights" className="nav-link">insights</Link>
-          <Link to="/contact" className="nav-link">contact</Link>
-          <div className="ml-2 pl-2 border-l border-border">
-            <ThemeToggle />
-          </div>
-        </nav>
+        <div className="nav__links">
+          <Link className="nav__link" to="/services">Services</Link>
+          <Link className="nav__link" to="/about">About</Link>
+          <Link className="nav__link" to="/insights">Writing</Link>
+          <Link className="nav__link" to="/lab">Lab</Link>
+          <Link className="nav__link" to="/contact">Contact</Link>
+        </div>
 
-        {/* Mobile menu */}
-        <div className="md:hidden flex items-center gap-2">
-          <ThemeToggle />
-          <MobileMenu />
+        <div className="nav__actions">
+          <button
+            className="icon-btn"
+            onClick={toggleTheme}
+            aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+          </button>
+          <Link className="btn btn--ghost nav__cta-desktop" to="/contact" style={{ padding: "0.55rem 1rem" }}>
+            Let's talk
+          </Link>
+          <div className="nav__mobile-toggle">
+            <MobileMenu />
+          </div>
         </div>
       </div>
-    </header>
+    </nav>
   );
 }
 
 function Footer() {
   return (
-    <footer className="mt-auto border-t border-border bg-background">
-      <div className="container py-8">
-        <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-          {/* Copyright */}
-          <p className="font-mono text-xs text-muted-foreground">
-            © {new Date().getFullYear()} D. E. Williams and Company
-          </p>
-
-          {/* Links */}
-          <div className="flex items-center gap-6">
-            <a
-              href="https://www.linkedin.com/in/danieleugenewilliams/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              LinkedIn
-            </a>
-            <a
-              href="https://twitter.com/dewilliamsco"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Twitter
-            </a>
-            <a
-              href="https://github.com/danieleugenewilliams"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              GitHub
-            </a>
-            <Link
-              to="/lab"
-              className="font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Lab
-            </Link>
-            <Link
-              to="/privacy"
-              className="font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Privacy
-            </Link>
+    <footer className="footer-new">
+      <div className="shell">
+        <div className="footer-new__top">
+          <div>
+            <div className="footer-new__wordmark">
+              D. E. Williams <em>+</em> Co.
+            </div>
+            <p className="footer-new__tagline">
+              AI transformation leadership — embedded. Strategy, architecture, implementation,
+              and team enablement from a single operator.
+            </p>
           </div>
+          <div className="footer-new__col">
+            <h4>Navigate</h4>
+            <ul>
+              <li><Link to="/services">Services</Link></li>
+              <li><Link to="/about">About</Link></li>
+              <li><Link to="/insights">Writing</Link></li>
+              <li><Link to="/lab">Lab</Link></li>
+            </ul>
+          </div>
+          <div className="footer-new__col">
+            <h4>Connect</h4>
+            <ul>
+              <li><a href="mailto:DanielEugeneWilliams@gmail.com">Email</a></li>
+              <li><a href="https://linkedin.com/in/danieleugenewilliams" target="_blank" rel="noreferrer">LinkedIn</a></li>
+              <li><a href="https://claudecodefornoncoders.substack.com" target="_blank" rel="noreferrer">Newsletter</a></li>
+              <li><a href="https://github.com/danieleugenewilliams" target="_blank" rel="noreferrer">GitHub</a></li>
+            </ul>
+          </div>
+          <div className="footer-new__col">
+            <h4>Legal</h4>
+            <ul>
+              <li><Link to="/privacy">Privacy</Link></li>
+            </ul>
+          </div>
+        </div>
+        <div className="footer-new__bottom">
+          <span>© {new Date().getFullYear()} D. E. Williams and Company</span>
+          <span>Designed for shipping, not decks.</span>
         </div>
       </div>
     </footer>
@@ -106,10 +120,8 @@ function Footer() {
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { pathname } = useLocation();
 
-  // Lenis smooth scroll
   useEffect(() => {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const lenis = new Lenis({ duration: 1.2, easing: (t: number) => 1 - Math.pow(1 - t, 3) });
     function raf(time: number) {
       lenis.raf(time);
@@ -119,15 +131,14 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     return () => lenis.destroy();
   }, []);
 
-  // Scroll to top on route change
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground w-full overflow-x-hidden">
-      <Header />
-      <main className="flex-1 w-full overflow-x-hidden">
+    <div className="flex min-h-screen flex-col w-full overflow-x-hidden" style={{ background: "var(--bg)", color: "var(--fg)" }}>
+      <Nav />
+      <main className="flex-1 w-full overflow-x-hidden" style={{ paddingTop: "3.5rem" }}>
         {children}
       </main>
       <Footer />

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -1,0 +1,28 @@
+const CLIENTS = [
+  'TaxAct',
+  'NFL Digital Media',
+  'Federal Reserve Board',
+  'Toyota',
+  'Lexus',
+  'Booz Allen Hamilton',
+  'Pariveda Solutions',
+  'Daylight Transport',
+  'Stop Soldier Suicide',
+  'JFFLabs',
+];
+
+export function MarqueeStrip() {
+  const loop = [...CLIENTS, ...CLIENTS];
+  return (
+    <div className="marquee" aria-hidden="true">
+      <div className="marquee__track">
+        {loop.map((name, i) => (
+          <span className="marquee__item" key={i}>
+            <span className="sep" />
+            {name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -17,7 +17,7 @@ export function MarqueeStrip() {
     <div className="marquee" aria-hidden="true">
       <div className="marquee__track">
         {loop.map((name, i) => (
-          <span className="marquee__item" key={i}>
+          <span className="marquee__item" key={`${name}-${i}`}>
             <span className="sep" />
             {name}
           </span>

--- a/src/components/ProblemSection.tsx
+++ b/src/components/ProblemSection.tsx
@@ -2,37 +2,31 @@ import { Reveal } from './Reveal';
 
 export function ProblemSection() {
   return (
-    <section className="section-padding section-alt">
-      <div className="container max-w-4xl">
+    <section className="section rule-top" id="problem">
+      <div className="shell problem__grid">
         <Reveal>
-          <h2 className="font-mono text-sm text-muted-foreground mb-8">
-            // THE_PROBLEM
+          <span className="eyebrow">01 — The problem</span>
+          <h2 className="problem__quote" style={{ marginTop: '1.5rem' }}>
+            Most companies are stuck between <em>AI</em> ambition and AI{' '}
+            <span className="brand-accent">execution.</span>
           </h2>
         </Reveal>
 
-        <div className="space-y-6 text-lg leading-relaxed">
-          <Reveal delay={1}>
-            <p className="text-foreground font-semibold text-section-display">
-              Most companies are stuck between AI ambition and AI execution.
-            </p>
-          </Reveal>
-
-          <Reveal delay={2}>
-            <p className="text-muted-foreground">
-              MIT research confirms it: despite $30–40 billion in enterprise GenAI investment,
-              95% of organizations are getting zero return. Only 5% have crossed from pilot
-              to production. The barrier isn't the technology — it's brittle workflows,
-              lack of contextual learning, and misalignment with day-to-day operations.
-              Closing that gap requires someone who has done it before.
-            </p>
-          </Reveal>
-
-          <Reveal delay={3}>
-            <p className="text-foreground font-mono text-xl md:text-2xl border-l-2 border-terminal-cyan pl-4">
-              That's the work I do.
-            </p>
-          </Reveal>
-        </div>
+        <Reveal delay={2} className="problem__body">
+          <p>
+            MIT research confirms it: despite $30–40 billion in enterprise GenAI investment,
+            95% of organizations are getting zero return. Only 5% have crossed from pilot
+            to production. The barrier isn't the technology — it's brittle workflows,
+            lack of contextual learning, and misalignment with day-to-day operations.
+          </p>
+          <p>
+            Closing that gap requires someone who has done it before.
+          </p>
+          <p style={{ color: 'var(--fg)', fontWeight: 500 }}>
+            That's the work I do.
+          </p>
+          <span className="kicker">→ I've shipped through it. Repeatedly.</span>
+        </Reveal>
       </div>
     </section>
   );

--- a/src/components/ProofSection.tsx
+++ b/src/components/ProofSection.tsx
@@ -1,60 +1,84 @@
 import { Reveal } from './Reveal';
+import { CountUp } from './CountUp';
 
 export function ProofSection() {
-  const proofPoints = [
-    {
-      metric: '$2.5M saved in year one',
-      description: 'Led TaxAct\'s legacy modernization, advising the CTO and President directly. Built custom ML-driven crawler to map 20-year-old C++ logic paths, then automated conversion to modern C# and React.',
-    },
-    {
-      metric: '$28K → $4M in 9 months',
-      description: 'Grew Daylight Transport from pilot to $4M engagement through integrated product strategy, executive alignment, and a logistics OS incorporating ML into route planning.',
-    },
-    {
-      metric: '$5M annual operational savings',
-      description: 'Reimagined NFL Digital Media\'s organizational design for a 1,000+ person org in 12 weeks. Redesigned roles, team structure, and technology platform strategy. Pariveda remains embedded to this day.',
-    },
-    {
-      metric: 'Zero loss of life',
-      description: 'Led customer strategy for Stop Soldier Suicide\'s Black Box Project; rearchitected AWS platform using AI/ML to identify markers for suicidality for clinicians serving veterans.',
-    },
-    {
-      metric: '17,000+ newsletter subscribers',
-      description: 'Claude Code for Non-Coders is the largest independent newsletter demystifying AI-native development for business leaders. Direct distribution channel converting readers into advisory clients and workshop attendees.',
-    },
-  ];
-
   return (
-    <section id="proof" className="section-padding section-alt">
-      <div className="container max-w-4xl">
+    <section className="section rule-top" id="work">
+      <div className="shell proof__head">
         <Reveal>
-          <h2 className="font-mono text-sm text-muted-foreground mb-8">
-            // PROOF
+          <span className="eyebrow">03 — Receipts</span>
+          <h2 className="t-display" style={{ marginTop: '1.5rem', maxWidth: '20ch' }}>
+            Outcomes, not{' '}
+            <em style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>activities.</em>
           </h2>
         </Reveal>
+        <Reveal delay={2}>
+          <p className="t-lead t-muted-new">
+            These aren't "advised on AI." These are shipped solutions that moved
+            revenue, saved operating cost, and — in one case — saved lives.
+          </p>
+        </Reveal>
+      </div>
 
-        <div className="space-y-8">
-          {proofPoints.map((point, index) => (
-            <Reveal key={index} delay={Math.min(index + 1, 4) as 1 | 2 | 3 | 4}>
-              <div className="border-l-2 border-terminal-cyan pl-6 py-2">
-                <p className="font-mono text-metric-display font-semibold text-foreground mb-2">
-                  {point.metric}
-                </p>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  {point.description}
-                </p>
-              </div>
-            </Reveal>
-          ))}
-        </div>
-
-        <Reveal delay={4}>
-          <div className="mt-10 border border-terminal-cyan/30 bg-terminal-cyan/5 p-6 text-center">
-            <p className="font-mono text-sm text-terminal-cyan mb-1">
-              Powered by the WARE Framework
+      <div className="shell">
+        <Reveal className="proof__grid">
+          <div className="proof__cell">
+            <span className="proof__cell__label">TaxAct</span>
+            <div className="proof__cell__metric">
+              $<CountUp to={2.5} format={(n) => n.toFixed(1)} />M
+              <span className="unit">saved · yr 1</span>
+            </div>
+            <p className="proof__cell__body">
+              Led legacy modernization — automatically converting 20-year-old C++ to modern
+              C# and React, then scaling the solution across their codebase.
             </p>
-            <p className="text-sm text-muted-foreground">
-              Workforce analytics built on O*NET structural data, LLM semantic analysis, and real-world adoption signals.
+          </div>
+
+          <div className="proof__cell proof__cell--feature">
+            <span className="proof__cell__label">Daylight Transport</span>
+            <div className="proof__cell__metric">
+              $<CountUp to={28} format={(n) => Math.round(n).toString()} />K →{' '}
+              $<CountUp to={4} format={(n) => Math.round(n).toString()} />M
+              <span className="unit">in 9 months</span>
+            </div>
+            <p className="proof__cell__body">
+              Accelerated a client's transformation through integrated product strategy,
+              technical architecture, and executive alignment.
+            </p>
+          </div>
+
+          <div className="proof__cell">
+            <span className="proof__cell__label">NFL Digital Media</span>
+            <div className="proof__cell__metric">
+              $<CountUp to={5} format={(n) => Math.round(n).toString()} />M
+              <span className="unit">annual opex</span>
+            </div>
+            <p className="proof__cell__body">
+              Reimagined organizational design and product engineering strategy for a
+              1,000+ person org in 12 weeks.
+            </p>
+          </div>
+
+          <div className="proof__cell">
+            <span className="proof__cell__label">Booz Allen Hamilton</span>
+            <div className="proof__cell__metric">
+              $<CountUp to={9} format={(n) => Math.round(n).toString()} />M+
+              <span className="unit">new business</span>
+            </div>
+            <p className="proof__cell__body">
+              Built and led consulting practices generating $6M+ annually across financial
+              services, transportation, and media.
+            </p>
+          </div>
+
+          <div className="proof__cell">
+            <span className="proof__cell__label">Stop Soldier Suicide</span>
+            <div className="proof__cell__metric">
+              Zero<span className="unit">loss of life</span>
+            </div>
+            <p className="proof__cell__body">
+              Led customer strategy for platform rearchitecture — AI-driven suicidality
+              signals for clinicians serving veterans.
             </p>
           </div>
         </Reveal>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -25,9 +25,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
-    // Apply theme to document
+    // Apply theme to document — both class (Tailwind) and data-theme (new design system)
     document.documentElement.classList.remove('light', 'dark');
     document.documentElement.classList.add(theme);
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.dataset.accent = 'ember';
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/src/components/WhatIDo.tsx
+++ b/src/components/WhatIDo.tsx
@@ -1,13 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
-
-function ArrowUpRight() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M5 11L11 5M6 5h5v5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
-    </svg>
-  );
-}
+import { ArrowUpRight } from './Icons';
 
 const CELLS = [
   {

--- a/src/components/WhatIDo.tsx
+++ b/src/components/WhatIDo.tsx
@@ -1,65 +1,61 @@
+import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
+
+function ArrowUpRight() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M5 11L11 5M6 5h5v5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}
+
+const CELLS = [
+  {
+    num: 'A — Process → Architecture',
+    title: <>Find where AI <em>actually</em> creates value.</>,
+    desc: "Operations mapping to locate the leverage points — not where it sounds impressive, where it moves the business.",
+  },
+  {
+    num: 'B — Implementation',
+    title: <>Ship <em>production</em> systems, not prototypes.</>,
+    desc: "Architecture, build, integration, and hardening. The work ends when something is making money — not when the slide deck ships.",
+  },
+  {
+    num: 'C — Team enablement',
+    title: <>Train your people to <em>own</em> it.</>,
+    desc: "Knowledge transfer isn't a phase, it's the whole point. You walk away with an internal team that can maintain and extend.",
+  },
+];
 
 export function WhatIDo() {
   return (
-    <section className="section-padding">
-      <div className="container max-w-4xl">
-        <Reveal>
-          <h2 className="font-mono text-sm text-muted-foreground mb-8">
-            // WHAT_I_DO
-          </h2>
-        </Reveal>
-
-        <Reveal delay={1}>
-          <p className="text-lg text-foreground mb-10 max-w-2xl">
-            <span className="font-semibold">I don't advise from the sidelines.</span>{' '}
-            I embed, build, and lead.
-          </p>
-        </Reveal>
-
-        <div className="grid md:grid-cols-3 gap-8 mb-10">
-          <Reveal delay={1}>
-            <div className="border border-border p-6 hover:border-terminal-cyan/50 transition-colors h-full">
-              <h3 className="font-mono text-base font-semibold mb-3">
-                [01] Embed
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                I join your leadership team as Fractional CTO or AI Transformation Officer.
-                Architecture decisions, vendor orchestration, AI governance, and the
-                stakeholder alignment that makes transformation stick.
-              </p>
-            </div>
+    <section className="section" id="services">
+      <div className="shell">
+        <div className="what__intro">
+          <Reveal>
+            <span className="eyebrow">02 — Services</span>
+            <h2 className="t-display" style={{ marginTop: '1.5rem', maxWidth: '18ch' }}>
+              I don't advise from the{' '}
+              <em style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>sidelines</em>.
+              I architect, build, and deploy.
+            </h2>
           </Reveal>
-
           <Reveal delay={2}>
-            <div className="border border-border p-6 hover:border-terminal-cyan/50 transition-colors h-full">
-              <h3 className="font-mono text-base font-semibold mb-3">
-                [02] Build
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Production systems, not prototypes. From AI-augmented workflows to
-                full platform modernization, I architect and ship alongside your team.
-              </p>
-            </div>
-          </Reveal>
-
-          <Reveal delay={3}>
-            <div className="border border-border p-6 hover:border-terminal-cyan/50 transition-colors h-full">
-              <h3 className="font-mono text-base font-semibold mb-3">
-                [03] Transfer
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                I train your people to maintain and extend what we build. The goal is
-                organizational capability, not consultant dependency.
-              </p>
-            </div>
+            <Link to="/services" className="btn btn--ghost">
+              Full services <ArrowUpRight />
+            </Link>
           </Reveal>
         </div>
 
-        <Reveal>
-          <p className="font-mono text-sm text-muted-foreground">
-            Powered by the WARE Framework and 20+ years of enterprise delivery.
-          </p>
+        <Reveal className="what__grid">
+          {CELLS.map((c) => (
+            <div key={c.num} className="what__cell">
+              <span className="what__cell__arrow"><ArrowUpRight /></span>
+              <span className="what__cell__num">{c.num}</span>
+              <h3 className="what__cell__title">{c.title}</h3>
+              <p className="what__cell__desc">{c.desc}</p>
+            </div>
+          ))}
         </Reveal>
       </div>
     </section>

--- a/src/components/WorkWithMe.tsx
+++ b/src/components/WorkWithMe.tsx
@@ -1,13 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
-
-function ArrowRight() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
-    </svg>
-  );
-}
+import { ArrowRight } from './Icons';
 
 export function WorkWithMe() {
   return (

--- a/src/components/WorkWithMe.tsx
+++ b/src/components/WorkWithMe.tsx
@@ -1,30 +1,41 @@
 import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
 
+function ArrowRight() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}
+
 export function WorkWithMe() {
   return (
-    <section className="section-padding section-alt">
-      <div className="container max-w-4xl text-center">
+    <section className="section cta-section" id="contact-cta">
+      <div className="shell">
         <Reveal>
-          <h2 className="font-mono text-sm text-muted-foreground mb-8">
-            // WORK_WITH_ME
+          <span className="eyebrow">07 — Work with me</span>
+          <h2 className="cta-section__title" style={{ marginTop: '1.5rem' }}>
+            Serious about AI transformation?
+            <br />
+            <span className="brand-accent">Let's talk.</span>
           </h2>
-        </Reveal>
-
-        <Reveal delay={1}>
-          <p className="text-lg text-foreground mb-6 max-w-xl mx-auto">
-            I take on 2–3 embedded engagements at a time. If your organization
-            needs AI transformation leadership — not just AI tools — let's talk.
+          <p className="cta-section__sub">
+            I take 2–3 clients at a time. If your organization needs AI transformation
+            leadership — not just AI tools — tell me what's stuck. I'll reply within
+            two business days.
           </p>
-        </Reveal>
-
-        <Reveal delay={2}>
-          <div className="flex flex-wrap justify-center gap-4">
-            <Link to="/contact" className="btn-primary">
-              [Book a Discovery Call]
+          <div style={{ marginTop: '2rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <Link to="/contact" className="btn">
+              Book a discovery call <ArrowRight />
             </Link>
-            <a href="https://automationresilience.com" target="_blank" rel="noopener noreferrer" className="btn-ghost">
-              Take the Free WARE Assessment {'>'}
+            <a
+              href="https://automationresilience.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn--ghost"
+            >
+              Take the Free WARE Assessment
             </a>
           </div>
         </Reveal>

--- a/src/components/WritingSection.tsx
+++ b/src/components/WritingSection.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { Reveal } from './Reveal';
+
+interface Post {
+  title: string;
+  link: string;
+  pubDate: string;
+  excerpt: string;
+}
+
+interface Feed {
+  id: string;
+  name: string;
+  posts: Post[];
+}
+
+interface PostsData {
+  fetchedAt: string;
+  feeds: Feed[];
+}
+
+function formatPostDate(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+function ArrowUpRight() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M5 11L11 5M6 5h5v5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
+    </svg>
+  );
+}
+
+export function WritingSection() {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    fetch('/data/posts.json')
+      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((data: PostsData) => {
+        const cc4nc = data.feeds.find((f) => f.id === 'cc4nc');
+        setPosts(cc4nc?.posts.slice(0, 3) ?? []);
+      })
+      .catch(() => {});
+  }, []);
+
+  if (posts.length === 0) return null;
+
+  return (
+    <section className="section rule-top" id="writing">
+      <div className="shell">
+        <div className="what__intro">
+          <Reveal>
+            <span className="eyebrow">06 — Writing</span>
+            <h2 className="t-display" style={{ marginTop: '1.5rem', maxWidth: '22ch' }}>
+              Field notes from the <em style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>build.</em>
+            </h2>
+          </Reveal>
+          <Reveal delay={2}>
+            <Link to="/insights" className="btn btn--ghost">
+              See all writing <ArrowUpRight />
+            </Link>
+          </Reveal>
+        </div>
+
+        <Reveal className="writing__grid">
+          {posts.map((p, i) => (
+            <a
+              key={i}
+              className="writing__item"
+              href={p.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className="writing__item__date">{formatPostDate(p.pubDate)}</span>
+              <h3 className="writing__item__title">{p.title}</h3>
+              <span className="writing__item__read">
+                Read essay <ArrowUpRight />
+              </span>
+            </a>
+          ))}
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/src/components/WritingSection.tsx
+++ b/src/components/WritingSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
+import { ArrowUpRight } from './Icons';
 
 interface Post {
   title: string;
@@ -29,28 +30,23 @@ function formatPostDate(dateStr: string): string {
   }
 }
 
-function ArrowUpRight() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M5 11L11 5M6 5h5v5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" />
-    </svg>
-  );
-}
-
 export function WritingSection() {
-  const [posts, setPosts] = useState<Post[]>([]);
+  const [posts, setPosts] = useState<Post[] | null>(null);
 
   useEffect(() => {
     fetch('/data/posts.json')
-      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error(`${r.status} ${r.url}`)))
       .then((data: PostsData) => {
         const cc4nc = data.feeds.find((f) => f.id === 'cc4nc');
         setPosts(cc4nc?.posts.slice(0, 3) ?? []);
       })
-      .catch(() => {});
+      .catch((e) => {
+        if (import.meta.env.DEV) console.warn('WritingSection fetch failed', e);
+        setPosts([]);
+      });
   }, []);
 
-  if (posts.length === 0) return null;
+  if (posts !== null && posts.length === 0) return null;
 
   return (
     <section className="section rule-top" id="writing">
@@ -69,23 +65,31 @@ export function WritingSection() {
           </Reveal>
         </div>
 
-        <Reveal className="writing__grid">
-          {posts.map((p, i) => (
-            <a
-              key={i}
-              className="writing__item"
-              href={p.link}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span className="writing__item__date">{formatPostDate(p.pubDate)}</span>
-              <h3 className="writing__item__title">{p.title}</h3>
-              <span className="writing__item__read">
-                Read essay <ArrowUpRight />
-              </span>
-            </a>
-          ))}
-        </Reveal>
+        {posts === null ? (
+          <div className="writing__grid writing__grid--skeleton" aria-busy="true" aria-label="Loading recent posts">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="writing__item writing__item--skeleton" />
+            ))}
+          </div>
+        ) : (
+          <Reveal className="writing__grid">
+            {posts.map((p) => (
+              <a
+                key={p.link}
+                className="writing__item"
+                href={p.link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="writing__item__date">{formatPostDate(p.pubDate)}</span>
+                <h3 className="writing__item__title">{p.title}</h3>
+                <span className="writing__item__read">
+                  Read essay <ArrowUpRight size={14} />
+                </span>
+              </a>
+            ))}
+          </Reveal>
+        )}
       </div>
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -337,6 +337,9 @@ html.lenis, html.lenis body { height: auto; }
   /* Easing */
   --ease-out-quart: cubic-bezier(0.16, 1, 0.3, 1);
 
+  /* Nav height — referenced in Layout main padding and hero offset */
+  --nav-h: 3.5rem;
+
   /* FOUC fallback — dark theme defaults applied before ThemeProvider hydrates */
   --bg: #0a0a0a;
   --bg-elev: #111110;
@@ -1075,6 +1078,19 @@ html.lenis, html.lenis body { height: auto; }
   transition: color 0.2s;
 }
 .writing__item:hover .writing__item__read { color: var(--brand); }
+.writing__item--skeleton {
+  min-height: 14rem;
+  background: linear-gradient(90deg, var(--surface) 25%, var(--surface-hover) 50%, var(--surface) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .writing__item--skeleton { animation: none; background: var(--surface); }
+}
 
 /* ---- work-with-me CTA ---- */
 .cta-section {

--- a/src/index.css
+++ b/src/index.css
@@ -4,19 +4,19 @@
 
 @layer base {
   :root {
-    /* Base colors - Light mode */
-    --background: 0 0% 98%;
-    --foreground: 0 0% 10%;
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 10%;
-    --border: 0 0% 90%;
-    --input: 0 0% 90%;
-    --ring: 187 72% 38%;
+    /* Base colors - Light mode (warm bone/ivory palette) */
+    --background: 35 30% 94%;
+    --foreground: 25 12% 10%;
+    --card: 36 30% 97%;
+    --card-foreground: 25 12% 10%;
+    --border: 35 15% 82%;
+    --input: 35 15% 82%;
+    --ring: 16 62% 50%;
     --radius: 0.25rem;
-    
+
     /* Muted */
-    --muted: 0 0% 96%;
-    --muted-foreground: 0 0% 42%;
+    --muted: 35 20% 90%;
+    --muted-foreground: 30 5% 40%;
     
     /* Primary - Cyan accent */
     --primary: 187 72% 38%;
@@ -51,20 +51,20 @@
   }
 
   .dark {
-    /* Base colors - Dark mode */
+    /* Base colors - Dark mode (matte black) */
     --background: 0 0% 4%;
-    --foreground: 0 0% 88%;
-    --card: 0 0% 7%;
-    --card-foreground: 0 0% 88%;
-    --border: 0 0% 15%;
-    --input: 0 0% 15%;
-    --ring: 187 72% 48%;
-    
+    --foreground: 40 8% 91%;
+    --card: 0 0% 6%;
+    --card-foreground: 40 8% 91%;
+    --border: 0 0% 16%;
+    --input: 0 0% 16%;
+    --ring: 16 62% 50%;
+
     /* Muted */
     --muted: 0 0% 10%;
-    --muted-foreground: 0 0% 56%;
-    
-    /* Primary - Cyan accent */
+    --muted-foreground: 40 4% 57%;
+
+    /* Primary - Cyan accent (kept for other pages) */
     --primary: 187 72% 48%;
     --primary-foreground: 0 0% 4%;
     
@@ -307,4 +307,848 @@ html.lenis, html.lenis body { height: auto; }
   /* Section backgrounds */
   .section-alt { background-color: hsl(var(--muted) / 0.3); }
   .section-accent { background-color: hsl(var(--card)); }
+}
+
+/* ============================================================
+   NEW DESIGN SYSTEM — editorial-luxe
+   Variables use --surface/--brand to avoid Tailwind conflicts
+   ============================================================ */
+
+/* Font variables */
+:root {
+  --font-display: "Fraunces", ui-serif, Georgia, serif;
+  --font-sans-new: "Inter Tight", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono-new: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* New type scale */
+  --fs-hero: clamp(3.25rem, 8.5vw, 9rem);
+  --fs-display: clamp(2.25rem, 5vw, 4.75rem);
+  --fs-section: clamp(1.6rem, 2.4vw, 2.25rem);
+  --fs-lead: clamp(1.125rem, 1.5vw, 1.35rem);
+  --fs-small: 0.825rem;
+  --fs-micro: 0.72rem;
+
+  /* Layout */
+  --gutter: clamp(1.25rem, 4vw, 3rem);
+  --section-y: clamp(5rem, 10vw, 9rem);
+  --section-y-sm: clamp(3rem, 6vw, 5rem);
+  --maxw: 1320px;
+
+  /* Easing */
+  --ease-out-quart: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* FOUC fallback — dark theme defaults applied before ThemeProvider hydrates */
+  --bg: #0a0a0a;
+  --bg-elev: #111110;
+  --bg-sunken: #070706;
+  --fg: #ece9e2;
+  --fg-muted: #9a968c;
+  --fg-dim: #5e5c56;
+  --rule: rgba(236, 233, 226, 0.09);
+  --rule-strong: rgba(236, 233, 226, 0.18);
+  --surface: #0f0f0e;
+  --surface-hover: #141412;
+  --brand: #d45a2b;
+  --brand-ink: #fff8f4;
+  --brand-soft: rgba(212, 90, 43, 0.1);
+}
+
+/* Dark theme tokens */
+[data-theme="dark"] {
+  --bg: #0a0a0a;
+  --bg-elev: #111110;
+  --bg-sunken: #070706;
+  --fg: #ece9e2;
+  --fg-muted: #9a968c;
+  --fg-dim: #5e5c56;
+  --rule: rgba(236, 233, 226, 0.09);
+  --rule-strong: rgba(236, 233, 226, 0.18);
+  --surface: #0f0f0e;
+  --surface-hover: #141412;
+}
+
+/* Light theme tokens */
+[data-theme="light"] {
+  --bg: #f5f1ea;
+  --bg-elev: #efeae1;
+  --bg-sunken: #ece7dc;
+  --fg: #171513;
+  --fg-muted: #6b6760;
+  --fg-dim: #a6a196;
+  --rule: rgba(23, 21, 19, 0.1);
+  --rule-strong: rgba(23, 21, 19, 0.22);
+  --surface: #fbf8f2;
+  --surface-hover: #ffffff;
+}
+
+/* Accent tokens */
+[data-accent="ember"] {
+  --brand: #d45a2b;
+  --brand-ink: #ffffff;
+  --brand-soft: rgba(212, 90, 43, 0.12);
+}
+[data-accent="cyan"] {
+  --brand: #22d3ee;
+  --brand-ink: #03131a;
+  --brand-soft: rgba(34, 211, 238, 0.14);
+}
+[data-accent="chartreuse"] {
+  --brand: #b6e04a;
+  --brand-ink: #0a0a0a;
+  --brand-soft: rgba(182, 224, 74, 0.15);
+}
+[data-accent="ink"] {
+  --brand: #e7e3da;
+  --brand-ink: #0a0a0a;
+  --brand-soft: rgba(231, 227, 218, 0.1);
+}
+[data-theme="light"][data-accent="ink"] {
+  --brand: #171513;
+  --brand-ink: #f5f1ea;
+  --brand-soft: rgba(23, 21, 19, 0.06);
+}
+
+/* Default accent fallback (before JS sets data-theme) */
+:root {
+  --brand: #d45a2b;
+  --brand-ink: #ffffff;
+  --brand-soft: rgba(212, 90, 43, 0.12);
+}
+
+/* Text selection */
+::selection { background: var(--brand); color: var(--brand-ink); }
+
+/* ---- layout helpers ---- */
+.shell {
+  width: 100%;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding-left: var(--gutter);
+  padding-right: var(--gutter);
+}
+
+.section {
+  padding-top: var(--section-y);
+  padding-bottom: var(--section-y);
+  position: relative;
+}
+
+.section--sm {
+  padding-top: var(--section-y-sm);
+  padding-bottom: var(--section-y-sm);
+}
+
+.rule-top { border-top: 1px solid var(--rule); }
+.rule-bottom { border-bottom: 1px solid var(--rule); }
+
+.eyebrow {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+/* ---- typography classes ---- */
+.t-hero {
+  font-family: var(--font-display);
+  font-size: var(--fs-hero);
+  font-weight: 300;
+  line-height: 0.93;
+  letter-spacing: -0.035em;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+}
+.t-hero em { font-style: italic; font-weight: 300; color: var(--fg-muted); }
+.t-hero .brand-accent { color: var(--brand); font-style: italic; }
+
+.t-display {
+  font-family: var(--font-display);
+  font-size: var(--fs-display);
+  font-weight: 400;
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  font-variation-settings: "opsz" 120;
+}
+
+.t-section {
+  font-family: var(--font-display);
+  font-size: var(--fs-section);
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.t-lead {
+  font-size: var(--fs-lead);
+  line-height: 1.5;
+  color: var(--fg);
+  font-weight: 400;
+  max-width: 56ch;
+}
+
+.t-mono-sm {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  letter-spacing: -0.005em;
+}
+
+.t-muted-new { color: var(--fg-muted); }
+.t-dim-new { color: var(--fg-dim); }
+.t-brand { color: var(--brand); }
+
+/* ---- new buttons ---- */
+.btn {
+  --btn-bg: var(--brand);
+  --btn-fg: var(--brand-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-sans-new);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  padding: 0.85rem 1.35rem;
+  border-radius: 999px;
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  border: 1px solid var(--btn-bg);
+  transition: transform 0.25s var(--ease-out-quart), background 0.25s, opacity 0.25s, border-color 0.25s;
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+}
+.btn:hover { transform: translateY(-1px); opacity: 0.92; text-decoration: none; }
+.btn:active { transform: translateY(0); }
+
+.btn--ghost {
+  --btn-bg: transparent;
+  --btn-fg: var(--fg);
+  border-color: var(--rule-strong);
+}
+.btn--ghost:hover { background: var(--surface-hover); border-color: var(--fg-muted); opacity: 1; }
+
+/* ---- nav ---- */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 50;
+  padding: 0.9rem 0;
+  background: color-mix(in oklab, var(--bg) 80%, transparent);
+  backdrop-filter: saturate(140%) blur(14px);
+  -webkit-backdrop-filter: saturate(140%) blur(14px);
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.3s, padding 0.3s var(--ease-out-quart);
+}
+.nav[data-scrolled="true"] {
+  border-bottom-color: var(--rule);
+  padding: 0.6rem 0;
+}
+.nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+.nav__brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+  color: var(--fg);
+  text-decoration: none;
+}
+.nav__brand .mark {
+  color: var(--brand);
+  font-style: italic;
+  padding: 0 0.1rem;
+}
+.nav__links {
+  display: none;
+  gap: 1.75rem;
+  align-items: center;
+}
+@media (min-width: 820px) {
+  .nav__links { display: inline-flex; }
+}
+.nav__link {
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--fg-muted);
+  letter-spacing: -0.005em;
+  transition: color 0.2s;
+  position: relative;
+  padding: 0.25rem 0;
+  text-decoration: none;
+}
+.nav__link:hover { color: var(--fg); text-decoration: none; }
+.nav__link::after {
+  content: "";
+  position: absolute;
+  left: 0; bottom: -2px;
+  height: 1px;
+  width: 0;
+  background: var(--brand);
+  transition: width 0.35s var(--ease-out-quart);
+}
+.nav__link:hover::after { width: 100%; }
+.nav__actions { display: inline-flex; align-items: center; gap: 0.65rem; }
+.nav__cta-desktop { display: none; }
+.nav__mobile-toggle { display: inline-flex; }
+@media (min-width: 820px) {
+  .nav__cta-desktop { display: inline-flex; }
+  .nav__mobile-toggle { display: none; }
+}
+
+.icon-btn {
+  width: 36px; height: 36px;
+  display: inline-grid; place-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--rule-strong, rgba(236,233,226,0.18));
+  color: var(--fg-muted);
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+  background: transparent;
+  cursor: pointer;
+}
+.icon-btn:hover { color: var(--fg); border-color: var(--fg-muted); background: var(--surface-hover); }
+
+/* ---- hero ---- */
+.hero {
+  padding-top: clamp(3.5rem, 8.5vw, 6.5rem);
+  padding-bottom: var(--section-y);
+  position: relative;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.hero__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: clamp(2.5rem, 5vw, 4rem);
+  flex-wrap: wrap;
+}
+
+.hero__meta .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #4ade80;
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.18);
+  animation: dot-pulse 2.4s infinite;
+}
+@keyframes dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+
+.hero__title { margin-bottom: clamp(2rem, 4vw, 3rem); }
+
+.hero__sub {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  align-items: end;
+  margin-top: clamp(2rem, 4vw, 3.5rem);
+}
+@media (min-width: 780px) {
+  .hero__sub { grid-template-columns: 1.2fr 1fr; }
+}
+
+.hero__ctas {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1.5rem;
+}
+.hero__stat .n {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 3.2vw, 2.6rem);
+  line-height: 1;
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  display: block;
+  color: var(--fg);
+}
+.hero__stat .l {
+  display: block;
+  margin-top: 0.5rem;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  color: var(--fg-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero__glyph {
+  position: absolute;
+  right: -4%;
+  top: 18%;
+  width: 44vw;
+  max-width: 620px;
+  aspect-ratio: 1;
+  pointer-events: none;
+  opacity: 0.08;
+  z-index: 0;
+}
+@media (max-width: 780px) {
+  .hero__glyph { opacity: 0.06; top: 6%; right: -18%; width: 110vw; }
+}
+.hero .shell { position: relative; z-index: 1; }
+
+/* ---- marquee ---- */
+.marquee {
+  --speed: 48s;
+  overflow: hidden;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 1.35rem 0;
+  background: var(--bg-sunken);
+  mask-image: linear-gradient(90deg, transparent, #000 10%, #000 90%, transparent);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 10%, #000 90%, transparent);
+}
+.marquee__track {
+  display: inline-flex;
+  gap: 3.5rem;
+  align-items: center;
+  animation: marquee-scroll var(--speed) linear infinite;
+  white-space: nowrap;
+  padding-left: 3.5rem;
+}
+.marquee__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--font-display);
+  font-size: clamp(1rem, 1.8vw, 1.35rem);
+  font-weight: 400;
+  color: var(--fg-muted);
+  letter-spacing: -0.02em;
+}
+.marquee__item .sep {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--brand);
+  opacity: 0.8;
+}
+@keyframes marquee-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+/* ---- problem ---- */
+.problem__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+}
+@media (min-width: 860px) {
+  .problem__grid { grid-template-columns: 5fr 7fr; gap: clamp(2rem, 5vw, 5rem); }
+}
+.problem__quote {
+  font-family: var(--font-display);
+  font-size: clamp(1.85rem, 3.2vw, 2.8rem);
+  line-height: 1.12;
+  font-weight: 300;
+  letter-spacing: -0.025em;
+  color: var(--fg);
+}
+.problem__quote em { font-style: italic; color: var(--fg-muted); font-weight: 300; }
+.problem__quote .brand-accent { color: var(--brand); font-style: italic; }
+.problem__body p { color: var(--fg-muted); font-size: var(--fs-lead); line-height: 1.6; }
+.problem__body p + p { margin-top: 1.25rem; }
+.problem__body .kicker {
+  display: inline-block;
+  margin-top: 2rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg);
+}
+
+/* ---- what i do ---- */
+.what__intro {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  margin-bottom: 3.5rem;
+  align-items: end;
+}
+@media (min-width: 860px) {
+  .what__intro { grid-template-columns: 1fr auto; }
+}
+
+.what__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  overflow: hidden;
+}
+@media (min-width: 860px) {
+  .what__grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.what__cell {
+  background: var(--bg);
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 280px;
+  transition: background 0.3s;
+  position: relative;
+}
+.what__cell:hover { background: var(--surface-hover); }
+.what__cell__num {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  letter-spacing: 0.12em;
+  color: var(--fg-dim);
+}
+.what__cell__title {
+  font-family: var(--font-display);
+  font-size: 1.55rem;
+  line-height: 1.12;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  margin-top: auto;
+  color: var(--fg);
+}
+.what__cell__title em { font-style: italic; color: var(--brand); }
+.what__cell__desc {
+  color: var(--fg-muted);
+  font-size: 0.98rem;
+  line-height: 1.55;
+  max-width: 38ch;
+}
+.what__cell__arrow {
+  position: absolute;
+  top: clamp(1.75rem, 2.5vw, 2.5rem);
+  right: clamp(1.75rem, 2.5vw, 2.5rem);
+  color: var(--fg-dim);
+  transition: color 0.3s, transform 0.3s var(--ease-out-quart);
+}
+.what__cell:hover .what__cell__arrow { color: var(--brand); transform: translate(3px, -3px); }
+
+/* ---- proof ---- */
+.proof__head {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  margin-bottom: clamp(3rem, 5vw, 4.5rem);
+  align-items: end;
+}
+@media (min-width: 860px) {
+  .proof__head { grid-template-columns: 1.2fr 1fr; }
+}
+
+.proof__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+@media (min-width: 620px) {
+  .proof__grid { grid-template-columns: 1fr 1fr; }
+}
+@media (min-width: 1024px) {
+  .proof__grid { grid-template-columns: repeat(5, 1fr); }
+}
+
+.proof__cell {
+  background: var(--bg);
+  padding: clamp(1.5rem, 2.4vw, 2.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-height: 240px;
+  transition: background 0.3s;
+  position: relative;
+  overflow: hidden;
+}
+.proof__cell:hover { background: var(--surface); }
+.proof__cell::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0;
+  height: 2px; width: 0;
+  background: var(--brand);
+  transition: width 0.6s var(--ease-out-quart);
+}
+.proof__cell:hover::before { width: 100%; }
+.proof__cell__metric {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 3.6vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-weight: 400;
+  color: var(--fg);
+}
+.proof__cell__metric .unit {
+  font-family: var(--font-mono-new);
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--fg-muted);
+  margin-left: 0.4rem;
+  letter-spacing: 0;
+}
+.proof__cell__label {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  color: var(--brand);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.proof__cell__body {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+  margin-top: auto;
+  max-width: 32ch;
+}
+@media (min-width: 1024px) {
+  .proof__cell--feature {
+    grid-column: span 2;
+    background: var(--bg-sunken);
+  }
+}
+
+/* ---- background/credentials ---- */
+.bg-section { background: var(--bg-sunken); }
+.bg-section__inner {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+}
+@media (min-width: 900px) {
+  .bg-section__inner { grid-template-columns: 5fr 7fr; gap: clamp(3rem, 7vw, 7rem); }
+}
+.bg-section__prose {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 2.2vw, 1.85rem);
+  line-height: 1.25;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.bg-section__prose em { font-style: italic; color: var(--fg-muted); }
+.bg-section__prose .brand-accent { color: var(--brand); font-style: italic; }
+.bg-section__prose p + p { margin-top: 1.4rem; }
+
+.credentials-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 2rem;
+}
+.credentials-tag {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  color: var(--fg-muted);
+}
+
+/* ---- how it works (steps) ---- */
+.steps {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+@media (min-width: 860px) {
+  .steps { grid-template-columns: repeat(3, 1fr); }
+}
+.step {
+  position: relative;
+  padding: clamp(1.75rem, 2.2vw, 2.25rem);
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 18px;
+  min-height: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: border-color 0.3s, transform 0.35s var(--ease-out-quart);
+  overflow: hidden;
+}
+.step:hover { border-color: var(--rule-strong); transform: translateY(-3px); }
+.step__num {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 3.5rem;
+  line-height: 1;
+  color: var(--brand);
+  font-weight: 300;
+}
+.step__badge {
+  align-self: flex-start;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  padding: 0.3rem 0.65rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  color: var(--fg-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.step__title {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  line-height: 1.15;
+  font-weight: 400;
+  margin-top: 0.25rem;
+  color: var(--fg);
+}
+.step__title em { font-style: italic; color: var(--brand); }
+.step__desc { color: var(--fg-muted); font-size: 0.98rem; line-height: 1.55; }
+.step__note {
+  margin-top: auto;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--brand);
+}
+
+/* ---- writing ---- */
+.writing__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+@media (min-width: 780px) {
+  .writing__grid { grid-template-columns: 1fr 1fr 1fr; }
+}
+.writing__item {
+  background: var(--bg);
+  padding: clamp(1.5rem, 2.4vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 240px;
+  transition: background 0.3s;
+  text-decoration: none;
+  color: inherit;
+}
+.writing__item:hover { background: var(--surface-hover); text-decoration: none; }
+.writing__item__date {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  color: var(--fg-dim);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.writing__item__title {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  line-height: 1.2;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  color: var(--fg);
+}
+.writing__item__read {
+  margin-top: auto;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: color 0.2s;
+}
+.writing__item:hover .writing__item__read { color: var(--brand); }
+
+/* ---- work-with-me CTA ---- */
+.cta-section {
+  background: var(--bg-sunken);
+  border-top: 1px solid var(--rule);
+}
+.cta-section__title {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 5.5vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+  font-weight: 300;
+  color: var(--fg);
+}
+.cta-section__title em { font-style: italic; color: var(--fg-muted); font-weight: 300; }
+.cta-section__title .brand-accent { color: var(--brand); font-style: italic; }
+.cta-section__sub {
+  margin-top: 1.5rem;
+  color: var(--fg-muted);
+  font-size: var(--fs-lead);
+  line-height: 1.55;
+  max-width: 44ch;
+}
+
+/* ---- new footer ---- */
+.footer-new {
+  padding: clamp(3rem, 5vw, 4.5rem) 0 2rem;
+  border-top: 1px solid var(--rule);
+  background: var(--bg);
+}
+.footer-new__top {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+  margin-bottom: 3rem;
+}
+@media (min-width: 780px) {
+  .footer-new__top { grid-template-columns: 2fr 1fr 1fr 1fr; }
+}
+.footer-new__wordmark {
+  font-family: var(--font-display);
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-weight: 300;
+  color: var(--fg);
+}
+.footer-new__wordmark em { color: var(--brand); font-style: italic; }
+.footer-new__tagline { color: var(--fg-muted); margin-top: 1rem; max-width: 38ch; line-height: 1.5; }
+.footer-new__col h4 {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-dim);
+  margin-bottom: 1rem;
+}
+.footer-new__col ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.65rem; }
+.footer-new__col a { color: var(--fg-muted); font-size: 0.95rem; transition: color 0.2s; text-decoration: none; }
+.footer-new__col a:hover { color: var(--fg); text-decoration: none; }
+.footer-new__bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marquee__track { animation: none; }
+  .dot-pulse { animation: none; }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,7 +76,14 @@ module.exports = {
         'metric-display': 'var(--heading-metric)',
       },
       fontFamily: {
+        display: [
+          'Fraunces',
+          'ui-serif',
+          'Georgia',
+          'serif',
+        ],
         sans: [
+          'Inter Tight',
           'Inter',
           'system-ui',
           '-apple-system',


### PR DESCRIPTION
## Summary

- Replaces terminal-mono homepage aesthetic with editorial-luxe design: Fraunces variable serif display type, Inter Tight body font, ember (#d45a2b) accent, warm bone/matte-black palette
- Adds three new components: `CountUp` (scroll-triggered animated counter), `MarqueeStrip` (infinite client name scroll), `WritingSection` (pulls 3 most recent posts from `/data/posts.json` Substack feed)
- Rewrites all homepage sections (Hero, Problem, WhatIDo, Proof, Credentials, HowItWorks, WorkWithMe) with new BEM component CSS appended to `index.css`
- Restores mobile nav (`MobileMenu`) dropped during layout rewrite; fixes hero double-padding; adds `:root` FOUC fallback variables for prerendered HTML
- Updates subscriber count to 23K+ across all hardcoded locations
- Dual token system: Tailwind HSL vars (`--background`, `--foreground`) kept intact for non-homepage pages; new hex vars (`--bg`, `--fg`, `--surface`, `--brand`) used by homepage components

## Test plan

- [ ] Homepage renders with Fraunces headlines, ember CTAs, dark default theme
- [ ] CountUp animates on scroll into view (stats grid in Hero and Proof sections)
- [ ] MarqueeStrip scrolls smoothly, pauses on `prefers-reduced-motion`
- [ ] WritingSection shows 3 real posts (run `node scripts/fetch-posts.mjs` if `public/data/posts.json` is stale)
- [ ] Mobile nav hamburger appears below 820px and all links work
- [ ] Light/dark theme toggle works; no flash of unstyled content on initial load
- [ ] Other pages (/services, /about, /lab, /insights) render correctly — no layout regressions from token changes
- [ ] `npm run build` passes with no TypeScript errors, all 9 routes prerendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)