### PR TITLE
feat: Insights page redesign — editorial-luxe

### DIFF
--- a/scripts/fetch-posts.mjs
+++ b/scripts/fetch-posts.mjs
@@ -28,7 +28,8 @@ const FEEDS = [
   },
 ];
 
-const MAX_POSTS_PER_FEED = 10;
+// Capture all posts the RSS feed provides (Substack returns up to 20)
+const MAX_POSTS_PER_FEED = 50;
 
 function parseItems(xml) {
   const items = [];
@@ -48,8 +49,12 @@ function parseItems(xml) {
       ? description.replace(/<[^>]+>/g, '').replace(/&#\d+;/g, ' ').trim().slice(0, 200)
       : '';
 
+    // Cover image from <enclosure url="...">
+    const enclosureMatch = block.match(/<enclosure url="([^"]+)"/);
+    const coverUrl = enclosureMatch ? enclosureMatch[1] : '';
+
     if (title && link) {
-      items.push({ title, link, pubDate, excerpt });
+      items.push({ title, link, pubDate, excerpt, coverUrl });
     }
   }
 

--- a/src/components/ConsultingHero.tsx
+++ b/src/components/ConsultingHero.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { Reveal } from './Reveal';
 import { CountUp } from './CountUp';
 import { ArrowRight } from './Icons';
+import { CC4NC_SUBSCRIBERS } from '../lib/constants';
 
 export function ConsultingHero() {
   return (
@@ -72,7 +73,7 @@ export function ConsultingHero() {
             </div>
             <div className="hero__stat">
               <span className="n">
-                <CountUp to={23} format={(n) => Math.round(n).toString()} />K+
+                <CountUp to={CC4NC_SUBSCRIBERS.count} format={(n) => Math.round(n).toString()} />K+
               </span>
               <span className="l">Newsletter subscribers</span>
             </div>

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { SEO } from './SEO';
 import { Reveal } from './Reveal';
+import { ArrowUpRight } from './Icons';
 
 interface Post {
   title: string;
   link: string;
   pubDate: string;
   excerpt: string;
+  coverUrl?: string;
 }
 
 interface Feed {
@@ -20,18 +22,72 @@ interface PostsData {
   feeds: Feed[];
 }
 
+interface FlatPost extends Post {
+  feedId: string;
+  feedName: string;
+}
+
 function formatDate(dateStr: string): string {
   try {
     const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   } catch {
     return '';
   }
 }
 
+function allSortedPosts(data: PostsData): FlatPost[] {
+  const flat: FlatPost[] = [];
+  for (const feed of data.feeds) {
+    for (const post of feed.posts) {
+      flat.push({ ...post, feedId: feed.id, feedName: feed.name });
+    }
+  }
+  flat.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime());
+  return flat;
+}
+
+// Derive topic counts by keyword-matching titles and excerpts
+function countByTopic(posts: FlatPost[]): Record<string, number> {
+  const topics: Array<{ key: string; patterns: RegExp }> = [
+    { key: 'Claude Code', patterns: /claude code|claude\b|coding agent/i },
+    { key: 'Agents & MCP', patterns: /\bagent|orchestrat|mcp\b|synthesis agent|worker/i },
+    { key: 'Workforce', patterns: /workforce|displacement|resilience|job categor|identity|parallel/i },
+    { key: 'AI Strategy', patterns: /ai strategy|enterprise|consulting|transform|pilot|stack/i },
+    { key: 'Memory & Data', patterns: /memory|local.memory|rag\b|data|systems of record/i },
+    { key: 'Product & Craft', patterns: /build|product|craft|ship|velocity|taste/i },
+  ];
+
+  const counts: Record<string, number> = {};
+  for (const topic of topics) {
+    counts[topic.key] = posts.filter((p) =>
+      topic.patterns.test(p.title) || topic.patterns.test(p.excerpt)
+    ).length;
+  }
+  return counts;
+}
+
+const TOPICS = [
+  { name: 'Claude Code', desc: 'Hands-on tutorials and architecture patterns' },
+  { name: 'Agents & MCP', desc: 'Orchestration, hooks, synthesis' },
+  { name: 'Workforce', desc: 'Displacement, resilience, identity' },
+  { name: 'AI Strategy', desc: 'Consulting, enterprise AI, stacks' },
+  { name: 'Memory & Data', desc: 'Local-Memory, RAG, systems of record' },
+  { name: 'Product & Craft', desc: 'Taste, velocity, the builder mindset' },
+];
+
+const FILTERS = [
+  { key: 'all', label: 'All essays' },
+  { key: 'cc4nc', label: 'Claude Code for Non-Coders' },
+  { key: 'dewco', label: 'D. E. Williams + Co.' },
+] as const;
+
 export default function Insights() {
   const [postsData, setPostsData] = useState<PostsData | null>(null);
   const [fetchFailed, setFetchFailed] = useState(false);
+  const [filter, setFilter] = useState<'all' | 'cc4nc' | 'dewco'>('all');
+  const [email, setEmail] = useState('');
 
   useEffect(() => {
     fetch('/data/posts.json')
@@ -43,147 +99,458 @@ export default function Insights() {
       .catch(() => setFetchFailed(true));
   }, []);
 
+  const allPosts = useMemo(() => (postsData ? allSortedPosts(postsData) : []), [postsData]);
+  const latest = allPosts[0] ?? null;
   const cc4nc = postsData?.feeds.find((f) => f.id === 'cc4nc');
-  const recentPosts = cc4nc?.posts.slice(0, 8) ?? [];
+  const dewco = postsData?.feeds.find((f) => f.id === 'dewco');
+  const cc4ncCount = cc4nc?.posts.length ?? 0;
+  const dewcoCount = dewco?.posts.length ?? 0;
+
+  const filteredPosts = useMemo(() => {
+    if (filter === 'all') return allPosts;
+    return allPosts.filter((p) => p.feedId === filter);
+  }, [allPosts, filter]);
+
+  const topicCounts = useMemo(() => countByTopic(allPosts), [allPosts]);
+  const latestDate = latest ? formatDate(latest.pubDate) : '';
+
+  const handleSubscribe = (e: React.FormEvent) => {
+    e.preventDefault();
+    const url =
+      'https://claudecodefornoncoders.substack.com/subscribe?email=' +
+      encodeURIComponent(email);
+    window.open(url, '_blank', 'noreferrer');
+  };
 
   return (
     <>
       <SEO
         title="Insights — D. E. Williams + Co."
-        description="AI transformation insights, Claude Code tutorials, and analysis of how automation is reshaping roles and industries."
+        description="Analysis, tutorials, and dispatches from the space between ambitious AI strategy and the teams who actually have to ship it."
         url="/insights"
       />
-      <main className="bg-background text-foreground w-full">
-        {/* Hero */}
-        <section className="section-padding bg-grid">
-          <div className="container max-w-4xl">
-            <div className="font-mono text-sm text-muted-foreground mb-6 animate-fade-in-1">
-              <span className="text-terminal-cyan">$</span> ls insights/
+
+      <main style={{ background: 'var(--bg)', color: 'var(--fg)' }}>
+
+        {/* ── Hero ── */}
+        <section className="ins-hero" id="top">
+          <div className="ins-hero__bg" />
+          <div className="ins-hero__grid" />
+          <div className="shell ins-hero__inner">
+            <Reveal>
+              <div className="ins-hero__meta">
+                <span className="dot" />
+                <span>Insights — vol. 03</span>
+                <span style={{ color: 'var(--fg-dim)' }}>/</span>
+                <span>{latestDate ? `Updated ${latestDate}` : 'Field notes'}</span>
+              </div>
+            </Reveal>
+
+            <Reveal delay={1}>
+              <h1 className="ins-hero__title">
+                <em>Field</em> notes<br />
+                from the <span className="ins-accent">gap.</span>
+              </h1>
+            </Reveal>
+
+            <div className="ins-hero__sub">
+              <Reveal delay={2}>
+                <p className="ins-hero__lede">
+                  Analysis, tutorials, and dispatches from the space between{' '}
+                  <strong>ambitious AI strategy</strong> and the teams who actually have to
+                  ship it. Two newsletters, written weekly. Read on Substack.
+                </p>
+              </Reveal>
+
+              <Reveal delay={3}>
+                <div className="ins-hero__stats">
+                  <div className="ins-hero__stat">
+                    <div className="n">{allPosts.length > 0 ? `${allPosts.length}+` : '—'}</div>
+                    <span className="l">Essays fetched</span>
+                  </div>
+                  <div className="ins-hero__stat">
+                    <div className="n">23k</div>
+                    <span className="l">Subscribers · CC4NC</span>
+                  </div>
+                  <div className="ins-hero__stat">
+                    <div className="n">Weekly</div>
+                    <span className="l">New posts, Tue + Thu</span>
+                  </div>
+                </div>
+              </Reveal>
             </div>
-            <h1 className="text-page-hero font-mono font-bold mb-6 animate-fade-in-2">
-              Insights
-            </h1>
-            <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl animate-fade-in-3">
-              Analysis, tutorials, and field notes on AI transformation, workforce
-              intelligence, and building with AI. Published on Substack.
-            </p>
           </div>
         </section>
 
-        {/* Newsletter Grid */}
-        <section className="section-padding">
-          <div className="container max-w-4xl">
-            <Reveal>
-              <h2 className="font-mono text-sm text-muted-foreground mb-8">
-                // NEWSLETTERS
-              </h2>
-            </Reveal>
-            <div className="grid md:grid-cols-2 gap-8">
-              {/* Claude Code for Non-Coders — Primary */}
+        {/* ── Featured ── */}
+        {latest && (
+          <section className="feat" id="featured">
+            <div className="shell">
+              <div className="feat__head">
+                <Reveal>
+                  <span className="eyebrow">Featured — this week</span>
+                </Reveal>
+                <Reveal delay={2}>
+                  <a
+                    className="t-mono t-muted"
+                    href={
+                      latest.feedId === 'cc4nc'
+                        ? 'https://claudecodefornoncoders.substack.com/'
+                        : 'https://dewilliamsco.substack.com/'
+                    }
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ fontSize: 'var(--fs-small)' }}
+                  >
+                    View all essays →
+                  </a>
+                </Reveal>
+              </div>
+
               <Reveal delay={1}>
-                <div className="border border-terminal-cyan/30 bg-terminal-cyan/5 p-8 hover:border-terminal-cyan/50 transition-colors h-full flex flex-col">
-                  <div className="font-mono text-xs text-terminal-cyan mb-4">
-                    [WEEKLY] · 23,000+ subscribers
+                <a
+                  className="feat__card"
+                  href={latest.link}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <div
+                    className="feat__cover"
+                    style={
+                      latest.coverUrl
+                        ? {
+                            backgroundImage: `linear-gradient(135deg, color-mix(in oklab, var(--bg-sunken) 70%, transparent), var(--bg-elev)), url(${latest.coverUrl})`,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                          }
+                        : undefined
+                    }
+                  >
+                    <span className="feat__cover__tag">
+                      <span
+                        style={{
+                          width: 6,
+                          height: 6,
+                          background: 'currentColor',
+                          borderRadius: '50%',
+                          display: 'inline-block',
+                        }}
+                      />
+                      {latest.feedId === 'cc4nc'
+                        ? 'Claude Code for Non-Coders'
+                        : 'D. E. Williams + Co.'}
+                    </span>
+                    <div className="feat__cover__index">
+                      <em>Latest</em>
+                      <br />essay
+                    </div>
                   </div>
-                  <h3 className="font-mono text-xl font-semibold mb-4">
-                    Claude Code for Non-Coders
+
+                  <div className="feat__body">
+                    <div className="feat__kicker">
+                      <span className="pub">
+                        {latest.feedId === 'cc4nc' ? 'CC4NC' : 'DEWCO'}
+                      </span>
+                      <span style={{ color: 'var(--fg-dim)' }}>·</span>
+                      <span>{formatDate(latest.pubDate)}</span>
+                    </div>
+                    <h3 className="feat__title">"{latest.title}"</h3>
+                    <p className="feat__dek">
+                      {latest.excerpt ||
+                        (latest.feedId === 'cc4nc'
+                          ? 'Part of the weekly series on practical AI development for business leaders — without deep technical expertise.'
+                          : 'Workforce intelligence analysis and commentary on how AI is reshaping roles and industries.')}
+                    </p>
+                    <div className="feat__footer">
+                      <span className="feat__read">
+                        Read on Substack
+                        <span className="feat__read__arrow">
+                          <ArrowUpRight />
+                        </span>
+                      </span>
+                      <span
+                        className="t-mono t-dim"
+                        style={{
+                          fontSize: 'var(--fs-micro)',
+                          letterSpacing: '0.1em',
+                          textTransform: 'uppercase',
+                        }}
+                      >
+                        ~ 6 min
+                      </span>
+                    </div>
+                  </div>
+                </a>
+              </Reveal>
+            </div>
+          </section>
+        )}
+
+        {/* ── Publications ── */}
+        <section className="pubs" id="publications">
+          <div className="shell">
+            <Reveal>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'end',
+                  gap: '1.5rem',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <div>
+                  <span className="eyebrow">Two publications</span>
+                  <h2
+                    className="t-display"
+                    style={{ marginTop: '1.25rem', maxWidth: '20ch' }}
+                  >
+                    Built to be read —{' '}
+                    <em style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>
+                      on purpose.
+                    </em>
+                  </h2>
+                </div>
+                <p className="t-lead t-muted" style={{ maxWidth: '36ch' }}>
+                  Each has a distinct remit. Subscribe to one, both, or neither — everything
+                  is public.
+                </p>
+              </div>
+            </Reveal>
+
+            <div className="pubs__grid">
+              <Reveal delay={1}>
+                <a
+                  className="pub-card"
+                  data-primary="true"
+                  href="https://claudecodefornoncoders.substack.com/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <div className="pub-card__kicker">
+                    <span className="tag">Weekly</span>
+                    <span>23,000+ subscribers</span>
+                  </div>
+                  <h3 className="pub-card__title">
+                    Claude Code <em>for</em> Non-Coders.
                   </h3>
-                  <p className="text-muted-foreground mb-6 leading-relaxed flex-1">
-                    The largest independent newsletter demystifying AI-native development
-                    for business leaders. Practical tutorials on building with Claude Code
+                  <p className="pub-card__desc">
+                    The largest independent newsletter demystifying AI-native development for
+                    business leaders. Practical tutorials on building with Claude Code —
                     without deep technical expertise.
                   </p>
+                  <div className="pub-card__footer">
+                    <div className="pub-card__stats">
+                      {cc4ncCount > 0 && (
+                        <span>
+                          <strong>{cc4ncCount}+</strong>RECENT ESSAYS
+                        </span>
+                      )}
+                      <span>
+                        <strong>Tue · Thu</strong>
+                      </span>
+                    </div>
+                    <span className="feat__read">
+                      Subscribe
+                      <span className="feat__read__arrow">
+                        <ArrowUpRight />
+                      </span>
+                    </span>
+                  </div>
+                </a>
+              </Reveal>
+
+              <Reveal delay={2}>
+                <a
+                  className="pub-card"
+                  href="https://dewilliamsco.substack.com/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <div className="pub-card__kicker">
+                    <span className="tag">Archive</span>
+                    <span>Active, occasional</span>
+                  </div>
+                  <h3 className="pub-card__title">
+                    D. E. Williams <em>+</em> Co. Insights.
+                  </h3>
+                  <p className="pub-card__desc">
+                    Workforce-intelligence analysis, lessons from building WARE and Local
+                    Memory, and commentary on how AI is reshaping roles and industries. The
+                    archive still reads.
+                  </p>
+                  <div className="pub-card__footer">
+                    <div className="pub-card__stats">
+                      {dewcoCount > 0 && (
+                        <span>
+                          <strong>{dewcoCount}+</strong>ESSAYS
+                        </span>
+                      )}
+                      <span>
+                        <strong>Long-form</strong>
+                      </span>
+                    </div>
+                    <span className="feat__read">
+                      Read archive
+                      <span className="feat__read__arrow">
+                        <ArrowUpRight />
+                      </span>
+                    </span>
+                  </div>
+                </a>
+              </Reveal>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Topics ── */}
+        {allPosts.length > 0 && (
+          <section className="topics" id="topics">
+            <div className="shell">
+              <Reveal>
+                <span className="eyebrow">Topics</span>
+                <h2
+                  className="t-display"
+                  style={{ marginTop: '1.25rem', maxWidth: '22ch' }}
+                >
+                  Six obsessions. In rotation.
+                </h2>
+              </Reveal>
+              <Reveal delay={1}>
+                <div className="topics__grid">
+                  {TOPICS.map((t) => {
+                    const count = topicCounts[t.name] ?? 0;
+                    return (
+                      <div key={t.name} className="topic">
+                        {count > 0 && <div className="topic__count">{count}</div>}
+                        <div className="topic__desc">{t.desc}</div>
+                        <div className="topic__name">// {t.name}</div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Reveal>
+            </div>
+          </section>
+        )}
+
+        {/* ── Archive ── */}
+        <section className="arch" id="archive">
+          <div className="shell">
+            <div className="arch__head">
+              <Reveal>
+                <div>
+                  <span className="eyebrow">Archive</span>
+                  <h2
+                    className="t-display"
+                    style={{ marginTop: '1.25rem', maxWidth: '20ch' }}
+                  >
+                    Every essay.{' '}
+                    <em style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>
+                      In reverse.
+                    </em>
+                  </h2>
+                </div>
+              </Reveal>
+              <Reveal delay={1}>
+                <div className="arch__filters" role="tablist" aria-label="Filter posts">
+                  {FILTERS.map((f) => (
+                    <button
+                      key={f.key}
+                      role="tab"
+                      aria-selected={filter === f.key}
+                      data-active={filter === f.key}
+                      className="arch__chip"
+                      onClick={() => setFilter(f.key)}
+                    >
+                      {f.label}
+                    </button>
+                  ))}
+                </div>
+              </Reveal>
+            </div>
+
+            <div className="arch__list">
+              {fetchFailed && (
+                <div className="arch__empty">
+                  Posts available on{' '}
                   <a
                     href="https://claudecodefornoncoders.substack.com/"
                     target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn-primary inline-block self-start"
+                    rel="noreferrer"
+                    style={{ color: 'var(--brand)' }}
                   >
-                    [Subscribe on Substack]
+                    Substack
                   </a>
+                  .
                 </div>
-              </Reveal>
-
-              {/* D. E. Williams + Co. Insights — Archive */}
-              <Reveal delay={2}>
-                <div className="border border-border p-8 hover:border-terminal-cyan/50 transition-colors h-full flex flex-col">
-                  <div className="font-mono text-xs text-muted-foreground mb-4">
-                    [ARCHIVE]
-                  </div>
-                  <h3 className="font-mono text-xl font-semibold mb-4">
-                    D. E. Williams + Co.
-                  </h3>
-                  <p className="text-muted-foreground mb-6 leading-relaxed flex-1">
-                    Workforce intelligence analysis, lessons from building WARE and Local Memory,
-                    and commentary on how AI is reshaping roles and industries.
-                    The archive is still worth reading.
-                  </p>
+              )}
+              {!fetchFailed && filteredPosts.length === 0 && allPosts.length === 0 && (
+                <div className="arch__empty">Loading essays…</div>
+              )}
+              {!fetchFailed && filteredPosts.length === 0 && allPosts.length > 0 && (
+                <div className="arch__empty">No essays match this filter.</div>
+              )}
+              {filteredPosts.map((p, i) => (
+                <Reveal key={p.link + i}>
                   <a
-                    href="https://dewilliamsco.substack.com/"
+                    className="arch__row"
+                    href={p.link}
                     target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn-primary inline-block self-start"
+                    rel="noreferrer"
                   >
-                    [Read on Substack]
+                    <span className="arch__date">{formatDate(p.pubDate)}</span>
+                    <h3 className="arch__title">"{p.title}"</h3>
+                    <span className="arch__meta">
+                      <span className={`pub-dot ${p.feedId}`} />
+                      {p.feedId === 'cc4nc' ? 'CC4NC' : 'DEWCO'}
+                    </span>
+                    <span className="arch__arrow">
+                      <ArrowUpRight />
+                    </span>
                   </a>
-                </div>
-              </Reveal>
+                </Reveal>
+              ))}
             </div>
           </div>
         </section>
 
-        {/* Recent Posts */}
-        <section className="section-padding section-alt">
-          <div className="container max-w-4xl">
+        {/* ── Subscribe CTA ── */}
+        <section className="sub-cta" id="subscribe">
+          <div className="shell">
             <Reveal>
-              <h2 className="font-mono text-sm text-muted-foreground mb-8">
-                // RECENT
-              </h2>
+              <div className="sub-cta__card">
+                <div className="sub-cta__inner">
+                  <span className="eyebrow">Subscribe</span>
+                  <h2 className="sub-cta__title">
+                    New essays <em>land</em> in your inbox —<br />
+                    <span className="ins-accent">twice a week.</span>
+                  </h2>
+                  <form className="sub-cta__form" onSubmit={handleSubscribe}>
+                    <input
+                      className="sub-cta__input"
+                      type="email"
+                      name="email"
+                      placeholder="you@company.com"
+                      required
+                      aria-label="Email address"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                    />
+                    <button type="submit" className="sub-cta__btn">
+                      Subscribe <ArrowUpRight />
+                    </button>
+                  </form>
+                  <p className="sub-cta__fine">
+                    Routes to Claude Code for Non-Coders on Substack · No spam, unsubscribe
+                    any time.
+                  </p>
+                </div>
+              </div>
             </Reveal>
-            {fetchFailed ? (
-              <div className="border border-border p-6 text-center">
-                <p className="text-muted-foreground mb-4">
-                  Latest posts are available on Substack.
-                </p>
-                <a
-                  href="https://claudecodefornoncoders.substack.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="btn-primary inline-block"
-                >
-                  [Read on Substack]
-                </a>
-              </div>
-            ) : recentPosts.length > 0 ? (
-              <div className="space-y-4">
-                {recentPosts.map((post, i) => (
-                  <Reveal key={post.link} delay={Math.min(i + 1, 4) as 1 | 2 | 3 | 4}>
-                    <a
-                      href={post.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block border border-border p-5 hover:border-terminal-cyan/50 transition-colors"
-                    >
-                      <p className="font-semibold text-foreground mb-1">{post.title}</p>
-                      <div className="flex items-center gap-3 font-mono text-xs text-muted-foreground">
-                        <span>Claude Code for Non-Coders</span>
-                        {post.pubDate && (
-                          <>
-                            <span>·</span>
-                            <span>{formatDate(post.pubDate)}</span>
-                          </>
-                        )}
-                        <span>→</span>
-                      </div>
-                    </a>
-                  </Reveal>
-                ))}
-              </div>
-            ) : (
-              <p className="text-muted-foreground font-mono text-sm">Loading recent posts...</p>
-            )}
           </div>
         </section>
+
       </main>
     </>
   );

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -3,6 +3,8 @@ import { SEO } from './SEO';
 import { Reveal } from './Reveal';
 import { ArrowUpRight } from './Icons';
 
+const CC4NC_SUBSCRIBERS = { short: '23k', full: '23,000+' };
+
 interface Post {
   title: string;
   link: string;
@@ -169,7 +171,7 @@ export default function Insights() {
                     <span className="l">Essays fetched</span>
                   </div>
                   <div className="ins-hero__stat">
-                    <div className="n">23k</div>
+                    <div className="n">{CC4NC_SUBSCRIBERS.short}</div>
                     <span className="l">Subscribers · CC4NC</span>
                   </div>
                   <div className="ins-hero__stat">
@@ -268,16 +270,6 @@ export default function Insights() {
                           <ArrowUpRight />
                         </span>
                       </span>
-                      <span
-                        className="t-mono t-dim"
-                        style={{
-                          fontSize: 'var(--fs-micro)',
-                          letterSpacing: '0.1em',
-                          textTransform: 'uppercase',
-                        }}
-                      >
-                        ~ 6 min
-                      </span>
                     </div>
                   </div>
                 </a>
@@ -329,7 +321,7 @@ export default function Insights() {
                 >
                   <div className="pub-card__kicker">
                     <span className="tag">Weekly</span>
-                    <span>23,000+ subscribers</span>
+                    <span>{CC4NC_SUBSCRIBERS.full} subscribers</span>
                   </div>
                   <h3 className="pub-card__title">
                     Claude Code <em>for</em> Non-Coders.
@@ -492,7 +484,7 @@ export default function Insights() {
                 <div className="arch__empty">No essays match this filter.</div>
               )}
               {filteredPosts.map((p, i) => (
-                <Reveal key={p.link + i}>
+                <Reveal key={p.link}>
                   <a
                     className="arch__row"
                     href={p.link}

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { SEO } from './SEO';
 import { Reveal } from './Reveal';
 import { ArrowUpRight } from './Icons';
-
-const CC4NC_SUBSCRIBERS = { short: '23k', full: '23,000+' };
+import { CC4NC_SUBSCRIBERS } from '../lib/constants';
 
 interface Post {
   title: string;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -44,7 +44,7 @@ function Nav() {
         <div className="nav__links">
           <Link className="nav__link" to="/services">Services</Link>
           <Link className="nav__link" to="/about">About</Link>
-          <Link className="nav__link" to="/insights">Writing</Link>
+          <Link className="nav__link" to="/insights">Insights</Link>
           <Link className="nav__link" to="/lab">Lab</Link>
           <Link className="nav__link" to="/contact">Contact</Link>
         </div>
@@ -88,7 +88,7 @@ function Footer() {
             <ul>
               <li><Link to="/services">Services</Link></li>
               <li><Link to="/about">About</Link></li>
-              <li><Link to="/insights">Writing</Link></li>
+              <li><Link to="/insights">Insights</Link></li>
               <li><Link to="/lab">Lab</Link></li>
             </ul>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import "./styles/tokens.css";
 @import "./styles/editorial.css";
 @import "./styles/about.css";
+@import "./styles/insights.css";
 
 @tailwind base;
 @tailwind components;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,6 @@
+// Subscriber counts — bump both values when milestones hit
+export const CC4NC_SUBSCRIBERS = {
+  count: 23,          // integer used by CountUp animation
+  short: '23k',       // hero stat display
+  full: '23,000+',    // badge/card display
+};

--- a/src/styles/insights.css
+++ b/src/styles/insights.css
@@ -201,12 +201,14 @@
   color: var(--fg);
   letter-spacing: 0.02em;
 }
-.feat__card:hover .feat__read { color: var(--brand); }
+.feat__card:hover .feat__read,
+.pub-card:hover .feat__read { color: var(--brand); }
 .feat__read__arrow {
   display: inline-block;
   transition: transform 0.3s var(--ease-out-quart);
 }
-.feat__card:hover .feat__read__arrow { transform: translate(3px, -3px); }
+.feat__card:hover .feat__read__arrow,
+.pub-card:hover .feat__read__arrow { transform: translate(3px, -3px); }
 
 /* ---- Publications strip ---- */
 .pubs {

--- a/src/styles/insights.css
+++ b/src/styles/insights.css
@@ -1,0 +1,542 @@
+/* ============================================================
+   INSIGHTS PAGE
+   ============================================================ */
+
+/* ---- Insights Hero ---- */
+.ins-hero {
+  position: relative;
+  padding-top: clamp(5rem, 10vw, 8rem);
+  padding-bottom: clamp(3rem, 5vw, 4rem);
+  overflow: hidden;
+  border-bottom: 1px solid var(--rule);
+}
+.ins-hero__bg {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(60% 80% at 90% 10%, color-mix(in oklab, var(--brand) 10%, transparent), transparent 60%);
+}
+.ins-hero__grid {
+  position: absolute; inset: 0;
+  background-image: linear-gradient(var(--rule) 1px, transparent 1px);
+  background-size: 100% 48px;
+  opacity: 0.5;
+  mask-image: linear-gradient(180deg, transparent, #000 30%, #000 70%, transparent);
+  -webkit-mask-image: linear-gradient(180deg, transparent, #000 30%, #000 70%, transparent);
+}
+.ins-hero__inner { position: relative; z-index: 2; }
+.ins-hero__meta {
+  display: flex; align-items: center; gap: 0.8rem;
+  margin-bottom: 2rem;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg-muted);
+}
+.ins-hero__meta .dot {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--brand);
+}
+.ins-hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(4rem, 12vw, 11rem);
+  font-weight: 300;
+  line-height: 0.88;
+  letter-spacing: -0.04em;
+  font-variation-settings: "opsz" 144, "SOFT" 40;
+  margin: 0;
+}
+.ins-hero__title em { font-style: italic; color: var(--fg-muted); font-weight: 300; }
+.ins-hero__title .ins-accent { color: var(--brand); font-style: italic; }
+.ins-hero__sub {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin-top: clamp(2rem, 4vw, 3rem);
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+}
+@media (min-width: 820px) {
+  .ins-hero__sub { grid-template-columns: 1.2fr 1fr; gap: 3rem; align-items: start; }
+}
+.ins-hero__lede {
+  font-size: var(--fs-lead);
+  line-height: 1.55;
+  color: var(--fg-muted);
+  max-width: 52ch;
+}
+.ins-hero__lede strong { color: var(--fg); font-weight: 500; }
+.ins-hero__stats {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem;
+}
+.ins-hero__stat {
+  border-left: 1px solid var(--rule);
+  padding-left: 1rem;
+}
+.ins-hero__stat .n {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--fg);
+}
+.ins-hero__stat .l {
+  display: block;
+  margin-top: 0.5rem;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-dim);
+}
+
+/* ---- Featured Essay ---- */
+.feat {
+  padding-top: var(--section-y-sm);
+  padding-bottom: var(--section-y-sm);
+}
+.feat__head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 1.5rem; flex-wrap: wrap;
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+}
+.feat__card {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  border: 1px solid var(--rule);
+  border-radius: 18px;
+  overflow: hidden;
+  transition: border-color 0.3s, background 0.3s;
+  background: var(--surface);
+  color: inherit;
+  text-decoration: none;
+}
+@media (min-width: 900px) {
+  .feat__card { grid-template-columns: 5fr 7fr; }
+}
+.feat__card:hover {
+  border-color: color-mix(in oklab, var(--brand) 50%, var(--rule-strong));
+  background: var(--surface-hover);
+}
+.feat__cover {
+  position: relative;
+  min-height: 360px;
+  background:
+    radial-gradient(80% 100% at 20% 20%, color-mix(in oklab, var(--brand) 18%, transparent), transparent 60%),
+    linear-gradient(135deg, var(--bg-sunken), var(--bg-elev));
+  display: flex; flex-direction: column; justify-content: space-between;
+  padding: 2rem;
+  border-right: 1px solid var(--rule);
+}
+@media (max-width: 899px) {
+  .feat__cover { border-right: none; border-bottom: 1px solid var(--rule); min-height: 240px; }
+}
+.feat__cover::before {
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(var(--rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--rule) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.6;
+  mask-image: radial-gradient(60% 80% at 80% 80%, #000 40%, transparent);
+  -webkit-mask-image: radial-gradient(60% 80% at 80% 80%, #000 40%, transparent);
+}
+.feat__cover__tag {
+  position: relative; z-index: 2;
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  font-family: var(--font-mono-new); font-size: var(--fs-micro);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--brand);
+  padding: 0.35rem 0.7rem;
+  border: 1px solid currentColor; border-radius: 999px;
+  align-self: flex-start;
+}
+.feat__cover__index {
+  position: relative; z-index: 2;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(4rem, 10vw, 9rem);
+  line-height: 0.8;
+  letter-spacing: -0.05em;
+  color: var(--fg);
+  opacity: 0.85;
+}
+.feat__cover__index em { font-style: italic; color: var(--fg-muted); }
+.feat__body {
+  padding: clamp(2rem, 3.5vw, 3rem);
+  display: flex; flex-direction: column; gap: 1.25rem;
+}
+.feat__kicker {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg-muted);
+  display: flex; gap: 0.75rem; align-items: center;
+}
+.feat__kicker .pub { color: var(--brand); }
+.feat__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 3.2vw, 2.75rem);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.08;
+  margin: 0;
+}
+.feat__title em { font-style: italic; color: var(--fg-muted); }
+.feat__dek {
+  font-size: var(--fs-lead);
+  line-height: 1.55;
+  color: var(--fg-muted);
+}
+.feat__footer {
+  margin-top: auto;
+  display: flex; justify-content: space-between; align-items: center;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  gap: 1rem;
+}
+.feat__read {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg);
+  letter-spacing: 0.02em;
+}
+.feat__card:hover .feat__read { color: var(--brand); }
+.feat__read__arrow {
+  display: inline-block;
+  transition: transform 0.3s var(--ease-out-quart);
+}
+.feat__card:hover .feat__read__arrow { transform: translate(3px, -3px); }
+
+/* ---- Publications strip ---- */
+.pubs {
+  background: var(--bg-sunken);
+  padding-top: var(--section-y-sm);
+  padding-bottom: var(--section-y-sm);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+.pubs__grid {
+  display: grid; grid-template-columns: 1fr; gap: 1rem;
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+@media (min-width: 820px) { .pubs__grid { grid-template-columns: repeat(2, 1fr); gap: 1.5rem; } }
+.pub-card {
+  position: relative;
+  display: flex; flex-direction: column; gap: 1rem;
+  padding: clamp(1.75rem, 2.5vw, 2.25rem);
+  border: 1px solid var(--rule);
+  border-radius: 16px;
+  background: var(--surface);
+  transition: transform 0.3s var(--ease-out-quart), border-color 0.3s, background 0.3s;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+}
+.pub-card::after {
+  content: "";
+  position: absolute; top: 0; left: 0; height: 2px; width: 0;
+  background: var(--brand);
+  transition: width 0.5s var(--ease-out-quart);
+}
+.pub-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--rule-strong);
+  background: var(--surface-hover);
+}
+.pub-card:hover::after { width: 100%; }
+.pub-card[data-primary="true"] {
+  border-color: color-mix(in oklab, var(--brand) 45%, var(--rule-strong));
+  background: linear-gradient(180deg, color-mix(in oklab, var(--brand) 6%, var(--surface)), var(--surface));
+}
+.pub-card__kicker {
+  display: flex; align-items: center; gap: 0.6rem;
+  font-family: var(--font-mono-new); font-size: var(--fs-micro);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.pub-card[data-primary="true"] .pub-card__kicker { color: var(--brand); }
+.pub-card__kicker .tag {
+  padding: 0.25rem 0.6rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+}
+.pub-card__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  font-weight: 400;
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+  margin: 0;
+}
+.pub-card__title em { font-style: italic; color: var(--fg-muted); }
+.pub-card__desc {
+  color: var(--fg-muted); line-height: 1.55;
+  font-size: 1rem;
+}
+.pub-card__footer {
+  margin-top: auto;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 1rem;
+}
+.pub-card__stats {
+  display: flex; gap: 1.25rem;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  color: var(--fg-muted);
+  letter-spacing: 0.04em;
+}
+.pub-card__stats strong {
+  font-weight: 500;
+  color: var(--fg);
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  margin-right: 0.2rem;
+}
+
+/* ---- Archive ---- */
+.arch {
+  padding-top: var(--section-y);
+  padding-bottom: var(--section-y);
+}
+.arch__head {
+  display: flex; justify-content: space-between; align-items: end;
+  gap: 2rem; flex-wrap: wrap;
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+}
+.arch__filters {
+  display: inline-flex; gap: 0.5rem; flex-wrap: wrap;
+  padding: 0.35rem;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  background: var(--surface);
+}
+.arch__chip {
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  letter-spacing: 0.02em;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.2s, background 0.2s;
+}
+.arch__chip:hover { color: var(--fg); }
+.arch__chip[data-active="true"] {
+  background: var(--brand);
+  color: var(--brand-ink);
+}
+.arch__list {
+  border-top: 1px solid var(--rule);
+}
+.arch__row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.4rem;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: start;
+  transition: padding 0.3s var(--ease-out-quart), background 0.3s;
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+}
+@media (min-width: 820px) {
+  .arch__row {
+    grid-template-columns: 110px 1fr 220px 40px;
+    gap: 2rem;
+    padding: 1.75rem 0.25rem;
+    align-items: center;
+  }
+}
+.arch__row:hover {
+  background: color-mix(in oklab, var(--brand) 4%, transparent);
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.arch__date {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  color: var(--fg-dim);
+  letter-spacing: 0.04em;
+}
+.arch__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 1.8vw, 1.45rem);
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+  color: var(--fg);
+  text-wrap: balance;
+  margin: 0;
+}
+.arch__row:hover .arch__title { color: var(--brand); }
+.arch__meta {
+  display: flex; gap: 0.5rem; align-items: center;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  color: var(--fg-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.arch__meta .pub-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+}
+.arch__meta .pub-dot.cc4nc { background: var(--brand); }
+.arch__meta .pub-dot.dewco { background: color-mix(in oklab, var(--fg) 35%, transparent); }
+.arch__arrow {
+  justify-self: end;
+  color: var(--fg-dim);
+  transition: color 0.2s, transform 0.3s var(--ease-out-quart);
+}
+.arch__row:hover .arch__arrow {
+  color: var(--brand);
+  transform: translate(3px, -3px);
+}
+.arch__empty {
+  padding: 3rem 0;
+  text-align: center;
+  color: var(--fg-muted);
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+}
+
+/* ---- Topics ---- */
+.topics {
+  padding-top: var(--section-y-sm);
+  padding-bottom: var(--section-y-sm);
+  background: var(--bg-sunken);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+.topics__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1px;
+  margin-top: clamp(2rem, 4vw, 3rem);
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.topic {
+  background: var(--surface);
+  padding: 1.5rem;
+  display: flex; flex-direction: column; gap: 0.5rem;
+  min-height: 140px;
+  transition: background 0.3s;
+}
+.topic:hover { background: var(--surface-hover); }
+.topic__count {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--brand);
+  font-weight: 400;
+}
+.topic__name {
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-small);
+  letter-spacing: 0.04em;
+  color: var(--fg);
+  margin-top: auto;
+}
+.topic__desc {
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  line-height: 1.45;
+}
+
+/* ---- Subscribe CTA ---- */
+.sub-cta {
+  padding-top: var(--section-y);
+  padding-bottom: var(--section-y);
+}
+.sub-cta__card {
+  border: 1px solid var(--rule-strong);
+  border-radius: 20px;
+  padding: clamp(2.5rem, 5vw, 4.5rem);
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(70% 100% at 100% 0%, color-mix(in oklab, var(--brand) 14%, transparent), transparent 60%),
+    linear-gradient(180deg, var(--surface), var(--surface-hover));
+}
+.sub-cta__card::before {
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(var(--rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--rule) 1px, transparent 1px);
+  background-size: 40px 40px;
+  opacity: 0.5;
+  mask-image: radial-gradient(60% 80% at 100% 0%, #000 10%, transparent 70%);
+  -webkit-mask-image: radial-gradient(60% 80% at 100% 0%, #000 10%, transparent 70%);
+  pointer-events: none;
+}
+.sub-cta__inner { position: relative; z-index: 2; }
+.sub-cta__title {
+  font-family: var(--font-display);
+  font-size: clamp(2.25rem, 5vw, 4rem);
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  max-width: 18ch;
+  margin: 1.5rem 0 0;
+}
+.sub-cta__title em { font-style: italic; color: var(--fg-muted); }
+.sub-cta__title .ins-accent { color: var(--brand); font-style: italic; }
+.sub-cta__form {
+  display: grid; grid-template-columns: 1fr; gap: 0.75rem;
+  margin-top: 2rem; max-width: 560px;
+}
+@media (min-width: 640px) {
+  .sub-cta__form { grid-template-columns: 1fr auto; }
+}
+.sub-cta__input {
+  font-family: var(--font-sans-new);
+  font-size: 1rem;
+  padding: 0.95rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--rule-strong);
+  background: var(--bg);
+  color: var(--fg);
+}
+.sub-cta__input:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 4px var(--brand-soft);
+}
+.sub-cta__fine {
+  margin-top: 1rem;
+  font-family: var(--font-mono-new);
+  font-size: var(--fs-micro);
+  color: var(--fg-dim);
+  letter-spacing: 0.04em;
+}
+
+/* Subscribe button — reuses editorial .btn style */
+.sub-cta__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-sans-new);
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.95rem 1.35rem;
+  border-radius: 999px;
+  background: var(--brand);
+  color: var(--brand-ink);
+  border: 1px solid var(--brand);
+  transition: transform 0.25s var(--ease-out-quart), opacity 0.25s;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.sub-cta__btn:hover { transform: translateY(-1px); opacity: 0.92; }
+.sub-cta__btn:active { transform: translateY(0); }


### PR DESCRIPTION
## Summary

- Redesigns the Insights page to match the editorial-luxe design system (consistent with the About and homepage redesigns)
- Expands the page from 3 sections to 6: Hero, Featured essay, Publications, Topics, Archive, Subscribe CTA
- Extends the RSS fetch pipeline to capture all 20 posts per feed (up from 10) and adds `coverUrl` from `<enclosure>` tags
- Topic counts derived from keyword-matching fetched post titles/excerpts — no hardcoded data
- Unifies nav and footer link label from "Writing" → "Insights"

## Changes

- `scripts/fetch-posts.mjs` — increases `MAX_POSTS_PER_FEED` to 50 (RSS returns 20), adds `coverUrl` extraction
- `src/styles/insights.css` — new file with all Insights-specific CSS (hero, featured card, pub cards, topics grid, archive list, subscribe CTA)
- `src/components/Insights.tsx` — full rewrite with 6 sections; data-driven post counts, featured post, and topic counts
- `src/components/Layout.tsx` — nav + footer "Writing" → "Insights"
- `src/index.css` — imports `insights.css`

## Test plan

- [ ] Visit `/insights` — all 6 sections render
- [ ] Featured card shows the most recent post title and excerpt
- [ ] Archive filter chips (All / CC4NC / DEWCO) correctly filter the list
- [ ] Subscribe form opens Substack subscribe URL in a new tab
- [ ] Nav and footer both show "Insights"
- [ ] Dark and light themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)