### PR TITLE
Refine cover + mobile UX; fix nav scrolling, hydration & /privacy routing

### DIFF
--- a/scripts/aws-setup.sh
+++ b/scripts/aws-setup.sh
@@ -130,10 +130,22 @@ SPA_FUNCTION_CODE=$(cat <<'JSEOF'
 function handler(event) {
   var request = event.request;
   var uri = request.uri;
+  // Static assets (they carry a file extension) pass through untouched.
   if (uri.includes('.')) {
     return request;
   }
-  request.uri = '/index.html';
+  // Map a clean URL to its prerendered document:
+  //   /         -> /index.html
+  //   /privacy  -> /privacy/index.html
+  //   /privacy/ -> /privacy/index.html
+  // Routes with no prerendered file (e.g. legacy /services) resolve to a
+  // missing S3 key; the distribution's 403/404 custom error response rewrites
+  // that to /index.html (200), so React Router's <Navigate> still handles them.
+  if (uri.endsWith('/')) {
+    request.uri = uri + 'index.html';
+  } else {
+    request.uri = uri + '/index.html';
+  }
   return request;
 }
 JSEOF
@@ -144,11 +156,38 @@ EXISTING_SPA_FN=$(aws cloudfront list-functions \
   --output text 2>/dev/null || true)
 
 if [ -n "$EXISTING_SPA_FN" ] && [ "$EXISTING_SPA_FN" != "None" ]; then
-  echo "CloudFront function $SPA_FUNCTION_NAME already exists"
+  echo "CloudFront function $SPA_FUNCTION_NAME already exists — updating code..."
+
+  # Write the current function code to a temp file.
+  TMPFILE=$(mktemp)
+  echo "$SPA_FUNCTION_CODE" > "$TMPFILE"
+
+  # The current ETag is required to update an existing function.
+  SPA_FN_ETAG=$(aws cloudfront describe-function \
+    --name "$SPA_FUNCTION_NAME" \
+    --query "ETag" \
+    --output text)
+
+  SPA_FN_ETAG=$(aws cloudfront update-function \
+    --name "$SPA_FUNCTION_NAME" \
+    --function-config '{"Comment":"Clean-URL routing - map paths to their prerendered index.html","Runtime":"cloudfront-js-2.0"}' \
+    --function-code "fileb://$TMPFILE" \
+    --if-match "$SPA_FN_ETAG" \
+    --query "ETag" \
+    --output text)
+
+  rm -f "$TMPFILE"
+
+  echo "Publishing updated function to LIVE stage..."
+  aws cloudfront publish-function \
+    --name "$SPA_FUNCTION_NAME" \
+    --if-match "$SPA_FN_ETAG" > /dev/null
+
   SPA_FN_ARN=$(aws cloudfront describe-function \
     --name "$SPA_FUNCTION_NAME" \
     --query "FunctionSummary.FunctionMetadata.FunctionARN" \
     --output text)
+  echo "Function updated and published: $SPA_FN_ARN"
 else
   echo "Creating CloudFront function: $SPA_FUNCTION_NAME..."
 
@@ -158,7 +197,7 @@ else
 
   SPA_FN_ETAG=$(aws cloudfront create-function \
     --name "$SPA_FUNCTION_NAME" \
-    --function-config '{"Comment":"SPA routing - rewrite non-file paths to /index.html","Runtime":"cloudfront-js-2.0"}' \
+    --function-config '{"Comment":"Clean-URL routing - map paths to their prerendered index.html","Runtime":"cloudfront-js-2.0"}' \
     --function-code "fileb://$TMPFILE" \
     --query "ETag" \
     --output text)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,6 +75,20 @@ aws s3 cp dist/index.html "s3://$S3_BUCKET/index.html" \
   --cache-control "no-cache, no-store, must-revalidate" \
   --content-type "text/html"
 
+# Upload prerendered per-route documents (e.g. privacy/index.html) with no cache.
+# The bulk sync above uploads them with the immutable asset header; re-upload via
+# cp (which always overwrites metadata) so route HTML can update between builds.
+# CloudFront's viewer-request function serves these for clean URLs (/privacy).
+echo "Uploading nested route documents (no cache)..."
+for route_doc in dist/*/index.html; do
+  [ -e "$route_doc" ] || continue
+  key="${route_doc#dist/}"
+  echo "  $key"
+  aws s3 cp "$route_doc" "s3://$S3_BUCKET/$key" \
+    --cache-control "no-cache, no-store, must-revalidate" \
+    --content-type "text/html"
+done
+
 # Upload JSON files (short cache)
 echo "Uploading JSON files (1 hour cache)..."
 aws s3 sync dist/ "s3://$S3_BUCKET" \
@@ -102,7 +116,7 @@ echo ""
 echo "--- Invalidating CloudFront ---"
 INVALIDATION_ID=$(aws cloudfront create-invalidation \
   --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
-  --paths "/index.html" "/" "/data/*" \
+  --paths "/index.html" "/" "/privacy" "/privacy/*" "/data/*" \
   --query "Invalidation.Id" \
   --output text)
 

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -11,7 +11,7 @@
 import puppeteer from 'puppeteer';
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,8 +65,17 @@ function createStaticServer(pristineHtml) {
     }
 
     // Real asset (.js/.css/.json/img/font) → serve from disk.
+    // Confine the resolved path to DIST_DIR: the request URL is untrusted, and
+    // join() normalizes any `..`, so a traversal like /../../etc/passwd would
+    // otherwise escape the build directory (CodeQL: uncontrolled path).
+    const filePath = join(DIST_DIR, urlPath);
+    if (filePath !== DIST_DIR && !filePath.startsWith(DIST_DIR + sep)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
     try {
-      const content = readFileSync(join(DIST_DIR, urlPath));
+      const content = readFileSync(filePath);
       res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
       res.end(content);
     } catch {

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -34,8 +34,13 @@ const ROUTES = [
   '/privacy',
 ];
 
-// Simple static file server for the dist directory
-function createStaticServer() {
+// Simple static file server for the dist directory.
+// `pristineHtml` is the untouched, empty-#root build shell; every route/SPA
+// request is served THAT (not a file from disk) so each route renders fresh via
+// the app's client render. Serving from disk would leak the '/' capture — which
+// overwrites dist/index.html — into '/privacy' and any route prerendered after
+// it, producing home-page HTML under the wrong route and a hydration mismatch.
+function createStaticServer(pristineHtml) {
   const mimeTypes = {
     '.html': 'text/html',
     '.js': 'application/javascript',
@@ -49,28 +54,24 @@ function createStaticServer() {
   };
 
   return createServer((req, res) => {
-    let filePath = join(DIST_DIR, req.url === '/' ? 'index.html' : req.url);
+    const urlPath = (req.url || '/').split('?')[0];
+    const ext = urlPath.includes('.') ? '.' + urlPath.split('.').pop() : '';
 
-    // SPA fallback — serve index.html for routes without extensions
-    if (!filePath.includes('.')) {
-      filePath = join(DIST_DIR, 'index.html');
+    // Route / SPA request (no extension, or an .html document) → pristine shell.
+    if (!ext || ext === '.html') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(pristineHtml);
+      return;
     }
 
+    // Real asset (.js/.css/.json/img/font) → serve from disk.
     try {
-      const content = readFileSync(filePath);
-      const ext = '.' + filePath.split('.').pop();
+      const content = readFileSync(join(DIST_DIR, urlPath));
       res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
       res.end(content);
     } catch {
-      // Fallback to index.html for SPA routes
-      try {
-        const content = readFileSync(join(DIST_DIR, 'index.html'));
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end(content);
-      } catch {
-        res.writeHead(404);
-        res.end('Not found');
-      }
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(pristineHtml);
     }
   });
 }
@@ -78,8 +79,12 @@ function createStaticServer() {
 async function prerender() {
   console.log('Starting prerender...');
 
+  // Snapshot the pristine build shell BEFORE any route capture overwrites
+  // dist/index.html, so every route is served an empty #root and renders fresh.
+  const pristineHtml = readFileSync(join(DIST_DIR, 'index.html'), 'utf8');
+
   // Start static server
-  const server = createStaticServer();
+  const server = createStaticServer(pristineHtml);
   await new Promise((resolve) => server.listen(PORT, resolve));
   console.log(`Static server running on http://localhost:${PORT}`);
 

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -11,7 +11,7 @@
 import puppeteer from 'puppeteer';
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
-import { join, dirname, sep } from 'path';
+import { join, dirname, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,11 +65,11 @@ function createStaticServer(pristineHtml) {
     }
 
     // Real asset (.js/.css/.json/img/font) → serve from disk.
-    // Confine the resolved path to DIST_DIR: the request URL is untrusted, and
-    // join() normalizes any `..`, so a traversal like /../../etc/passwd would
-    // otherwise escape the build directory (CodeQL: uncontrolled path).
+    // The request URL is untrusted and join() may resolve `..` outside dist/.
+    // Confine to DIST_DIR via relative()+`..` check (CodeQL js/path-injection).
     const filePath = join(DIST_DIR, urlPath);
-    if (filePath !== DIST_DIR && !filePath.startsWith(DIST_DIR + sep)) {
+    const rel = relative(DIST_DIR, filePath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
       res.writeHead(403);
       res.end('Forbidden');
       return;

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -53,8 +53,8 @@ export function AboutSection() {
                 companies that want the same thing for their teams. I work in a window from early
                 afternoon to evening, on purpose, because the mornings belong to my family, to
                 fitness, to reading, and to being in the room instead of half inside a meeting in my
-                head. I live on the coast of Virginia with my wife and two sons. <b>I would rather
-                ship than pitch.</b>
+                head. I live on the coast of Virginia with my wife and two sons. <b>Building a life 
+                worth living is the point.</b>
               </p>
             </div>
           </Reveal>

--- a/src/components/Condense.tsx
+++ b/src/components/Condense.tsx
@@ -1,0 +1,27 @@
+import { useState, type ReactNode } from 'react';
+
+/**
+ * Condense — full prose on desktop; short copy + a "More" toggle on mobile.
+ * Both variants render into the DOM (CSS `.d-only`/`.m-only` picks one by
+ * viewport), so the prerendered HTML and the client's first render match and
+ * hydration stays clean. The toggle only affects the mobile variant.
+ */
+export function Condense({ short, children }: { short: ReactNode; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <span className="d-only">{children}</span>
+      <span className="m-only">
+        {open ? children : short}
+        <button
+          type="button"
+          className="more-btn"
+          aria-expanded={open}
+          onClick={() => setOpen(!open)}
+        >
+          {open ? 'Less −' : 'More +'}
+        </button>
+      </span>
+    </>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,68 +2,83 @@ import { Reveal } from './Reveal';
 import { SubscribeForm } from './SubscribeForm';
 import { ArrowDown } from './Icons';
 import { CC4NC_SUBSCRIBERS } from '../lib/constants';
-import headshot from '../assets/headshot.jpg';
 
 export function Hero() {
   return (
     <header className="cover" id="top">
-      <div className="shell">
+      <div className="cover__bg" aria-hidden="true" />
+      <div className="cover__gridlines" aria-hidden="true" />
+      <div className="cover__portrait" aria-hidden="true" />
+      <div className="cover__caption d-only" aria-hidden="true">
+        <span>Daniel E. Williams · </span>
+        <span className="coral">Fig. 1</span>
+      </div>
+
+      <div className="shell cover__inner">
         <Reveal className="cover__folio">
           <span className="mark">Daniel E. Williams</span>
-          <span className="mark">Vol. I · Coastal Virginia · Est. MMXXV</span>
+          <span className="mark d-only">Vol. I · Coastal Virginia · Est. MMXXV</span>
+          <span className="mark m-only">Vol. I · MMXXV</span>
         </Reveal>
 
-        <div className="cover__grid">
+        <Reveal className="cover__eyebrows">
+          <span className="mark mark--coral">Architect / Operator · Coastal Virginia</span>
+          <span className="mark">{`Claude Code for Non-Coders · ${CC4NC_SUBSCRIBERS.full} readers`}</span>
+        </Reveal>
+
+        <Reveal delay={1}>
+          <h1 className="cover__title">
+            Point it<br />
+            at what<br />
+            <span className="coral">matters.</span>
+          </h1>
+        </Reveal>
+
+        <Reveal delay={2}>
+          <p className="cover__dek">
+            <span className="d-only">
+              For twenty-five years I built software and led consulting teams. Now I build my
+              own agents: the one that runs my training and sleep over Telegram, the memory
+              layer behind my writing, the systems that hand me back my mornings. <b>AI collapsed
+              the cost of expertise.</b> What's left is the question of what you point it at, and
+              I write about that every week.
+            </span>
+            <span className="m-only">
+              Twenty-five years building software for other people. Now I build my own
+              agents. <b>AI collapsed the cost of expertise</b> — what's left is what you
+              point it at. I write about that every week.
+            </span>
+          </p>
+        </Reveal>
+
+        <Reveal delay={2} className="cover__cta">
+          <SubscribeForm
+            caption={
+              <>
+                Claude Code for Non-Coders.
+                <em className="subform__cadence"> Thursdays: one consequential idea, free. Tuesdays: the hands-on build, paid.</em>
+              </>
+            }
+          />
+          <a className="cover__scroll" href="#believe">
+            Read what I believe <ArrowDown />
+          </a>
+        </Reveal>
+
+        <Reveal delay={3} className="cover__meta">
           <div>
-            <Reveal className="cover__eyebrows">
-              <span className="mark mark--coral">Architect / Operator · Coastal Virginia</span>
-              <span className="mark">{`Claude Code for Non-Coders · ${CC4NC_SUBSCRIBERS.full} readers`}</span>
-            </Reveal>
-
-            <Reveal delay={1}>
-              <h1 className="cover__title">
-                Point it<br />
-                at what<br />
-                <span className="coral">matters.</span>
-              </h1>
-            </Reveal>
-
-            <Reveal delay={2}>
-              <p className="cover__dek">
-                For twenty-five years I built software and led consulting teams. Now I build my
-                own agents: the one that runs my training and sleep over Telegram, the memory
-                layer behind my writing, the systems that hand me back my mornings. <b>AI collapsed
-                the cost of expertise.</b> What's left is the question of what you point it at, and
-                I write about that every week.
-              </p>
-            </Reveal>
-
-            <Reveal delay={2} className="cover__cta">
-              <SubscribeForm
-                caption={
-                  <>
-                    Claude Code for Non-Coders. <em>Tuesdays and Thursdays.</em>
-                  </>
-                }
-              />
-              <a className="cover__scroll" href="#believe">
-                Read what I believe <ArrowDown />
-              </a>
-            </Reveal>
+            <span className="k">Based</span>
+            <span className="v">Coastal Virginia</span>
           </div>
-
-          <Reveal delay={1} className="plate">
-            <div className="plate__frame">
-              <div className="plate__img">
-                <img src={headshot} alt="Daniel E. Williams" />
-              </div>
-            </div>
-            <div className="plate__cut">
-              <span>Daniel E. Williams</span>
-              <span className="coral">Fig. 1</span>
-            </div>
-          </Reveal>
-        </div>
+          <div>
+            <span className="k">Newsletter</span>
+            <span className="v">{`${CC4NC_SUBSCRIBERS.full} readers`}</span>
+          </div>
+          <div>
+            <span className="k">Focus</span>
+            <span className="v">Writing · Agents · Advisory</span>
+          </div>
+        </Reveal>
       </div>
     </header>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import Lenis from "lenis";
+import { ArrowRight } from "./Icons";
+
+const NAV_LINKS = [
+  { no: "02", label: "What I believe", href: "/#believe" },
+  { no: "03", label: "Writing", href: "/#writing" },
+  { no: "05", label: "Proof", href: "/#proof" },
+  { no: "06", label: "Work with me", href: "/#work" },
+  { no: "07", label: "About", href: "/#about" },
+];
 
 function Nav() {
   const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 12);
@@ -12,27 +22,82 @@ function Nav() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   return (
-    <nav className="nav" data-scrolled={scrolled ? "true" : "false"} aria-label="Primary">
-      <div className="shell nav__inner">
-        <Link to="/" className="nav__brand" aria-label="Daniel E. Williams, home">
-          <b>Daniel E. Williams</b>
-        </Link>
-
-        <div className="nav__links">
-          <a className="nav__link" href="/#writing">Writing</a>
-          <a className="nav__link" href="/#proof">Proof</a>
-          <a className="nav__link" href="/#work">Work with me</a>
-          <a className="nav__link" href="/#about">About</a>
-        </div>
-
-        <div className="nav__actions">
-          <a className="btn btn--sm" href="/#subscribe">
-            Subscribe
+    <>
+      <div
+        className="nav__scrim"
+        data-open={open ? "true" : "false"}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+      <div className="nav__menu" data-open={open ? "true" : "false"} id="mobile-menu" aria-hidden={!open}>
+        {NAV_LINKS.map((l) => (
+          <a key={l.href} className="nav__menu__link" href={l.href} onClick={() => setOpen(false)}>
+            <span>{l.label}</span>
+            <span className="no">{`§ ${l.no}`}</span>
           </a>
-        </div>
+        ))}
+        <a className="btn" href="/#subscribe" onClick={() => setOpen(false)}>
+          Subscribe
+          <span className="btn__arrow">
+            <ArrowRight />
+          </span>
+        </a>
       </div>
-    </nav>
+
+      <nav className="nav" data-scrolled={scrolled ? "true" : "false"} aria-label="Primary">
+        <div className="shell nav__inner">
+          <Link
+            to="/"
+            className="nav__brand"
+            aria-label="Daniel E. Williams, home"
+            onClick={() => setOpen(false)}
+          >
+            <b>Daniel E. Williams</b>
+          </Link>
+
+          <div className="nav__links">
+            {NAV_LINKS.map((l) => (
+              <a key={l.href} className="nav__link" href={l.href}>
+                {l.label}
+              </a>
+            ))}
+          </div>
+
+          <div className="nav__actions">
+            <a className="btn btn--sm d-only" href="/#subscribe">
+              Subscribe
+            </a>
+            <button
+              type="button"
+              className="nav__burger"
+              aria-label={open ? "Close menu" : "Open menu"}
+              aria-expanded={open}
+              aria-controls="mobile-menu"
+              onClick={() => setOpen(!open)}
+            >
+              {open ? (
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" strokeWidth="1.4" strokeLinecap="square" />
+                </svg>
+              ) : (
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M2 4.5h12M2 8h12M2 11.5h12" stroke="currentColor" strokeWidth="1.4" strokeLinecap="square" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+      </nav>
+    </>
   );
 }
 
@@ -65,12 +130,38 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const lenis = new Lenis({ duration: 1.2, easing: (t: number) => 1 - Math.pow(1 - t, 3) });
+    let rafId = 0;
     function raf(time: number) {
       lenis.raf(time);
-      requestAnimationFrame(raf);
+      rafId = requestAnimationFrame(raf);
     }
-    requestAnimationFrame(raf);
-    return () => lenis.destroy();
+    rafId = requestAnimationFrame(raf);
+
+    // Lenis owns the scroll position, so native in-page anchor jumps (and
+    // scrollIntoView) get reverted on the next frame. Route same-page hash
+    // links ("#work" or "/#work") through lenis.scrollTo so the nav, mobile
+    // menu, hero CTA, and footer "back to top" actually scroll — then sync the
+    // URL hash ourselves, since preventDefault stops the browser from doing it.
+    const onAnchorClick = (e: MouseEvent) => {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const anchor = (e.target as HTMLElement | null)?.closest?.('a[href*="#"]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href") || "";
+      const hash = href.slice(href.indexOf("#"));
+      if (hash.length < 2) return;
+      const el = document.querySelector(hash);
+      if (!el) return; // section isn't on this page — let the router navigate
+      e.preventDefault();
+      lenis.scrollTo(el as HTMLElement);
+      history.pushState(null, "", hash);
+    };
+    document.addEventListener("click", onAnchorClick);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      document.removeEventListener("click", onAnchorClick);
+      lenis.destroy();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { SEO } from "./SEO";
 
+// Static so the prerendered HTML and client render match (a live `new Date()`
+// renders the build-time date at prerender and the load-time date on the
+// client → hydration mismatch, React #418). Bump by hand when the policy changes.
+const LAST_UPDATED = "July 2, 2026";
+
 const PrivacyPolicy: React.FC = () => {
   return (
     <>
@@ -20,7 +25,7 @@ const PrivacyPolicy: React.FC = () => {
               Privacy Policy
             </h1>
             <p className="font-mono text-sm text-muted-foreground">
-              Last updated: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              {`Last updated: ${LAST_UPDATED}`}
             </p>
           </div>
         </section>
@@ -57,15 +62,15 @@ const PrivacyPolicy: React.FC = () => {
                 <h2 className="font-mono text-lg font-semibold mb-4">// THIRD-PARTY SERVICES</h2>
                 <div className="space-y-4 text-muted-foreground leading-relaxed">
                   <p>
-                    <strong className="text-foreground">Google Analytics:</strong> Website traffic analysis.{' '}
+                    <strong className="text-foreground">Google Analytics:</strong> Website traffic analysis.
                     <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-terminal-cyan hover:underline">
-                      Privacy policy →
+                      {" Privacy policy →"}
                     </a>
                   </p>
                   <p>
-                    <strong className="text-foreground">HubSpot:</strong> Contact form processing and CRM.{' '}
+                    <strong className="text-foreground">HubSpot:</strong> Contact form processing and CRM.
                     <a href="https://legal.hubspot.com/privacy-policy" target="_blank" rel="noopener noreferrer" className="text-terminal-cyan hover:underline">
-                      Privacy policy →
+                      {" Privacy policy →"}
                     </a>
                   </p>
                 </div>
@@ -93,9 +98,9 @@ const PrivacyPolicy: React.FC = () => {
                   Depending on location: access, correction, deletion, portability, objection, consent withdrawal.
                 </p>
                 <p className="text-muted-foreground">
-                  Contact:{' '}
+                  Contact:
                   <a href="/contact" className="text-terminal-cyan hover:underline">
-                    Get in touch
+                    {" Get in touch"}
                   </a>
                 </p>
               </div>

--- a/src/components/WhatIBelieve.tsx
+++ b/src/components/WhatIBelieve.tsx
@@ -1,8 +1,10 @@
 import { Reveal } from './Reveal';
+import { Condense } from './Condense';
 
 interface Belief {
   no: string;
   title: string;
+  short: string;
   body: string;
 }
 
@@ -10,26 +12,31 @@ const BELIEFS: Belief[] = [
   {
     no: '01',
     title: 'Value should accrue to the person, not the platform.',
+    short: 'When AI frees up days of work, someone picks that time up — by default, whoever owns the business. Build so it lands on you and the people you serve.',
     body: "When the work gets faster, it hands time back. A deck that took an analyst three days now takes an afternoon, and those saved days come loose and sit on the table. The fight everyone mislabels as AI versus jobs is really an older one, over who picks that time up. By default it rolls to whoever owns the business, quietly, without anyone in the building calling it a fight. It does not have to. Build so the freed value lands on you and the people you serve, not on whoever rents you the model.",
   },
   {
     no: '02',
     title: 'Stay the operator, not the assistant.',
+    short: "The risk isn't that AI replaces you — it's that it quietly demotes you to sign-off. Keep your hands on the decisions that carry weight.",
     body: "The real risk is not that AI replaces you. It is that it quietly demotes you. You feed the machine, it makes the call, and you sign off on whatever it hands back. The writer Cory Doctorow named that pattern the reverse-centaur, and I have watched capable people drift into it without noticing. Keep your hands on the decisions that carry weight, and pass off the rest on purpose. Sometimes the model really is better at a task than you are. The skill is being honest about which times those are.",
   },
   {
     no: '03',
     title: 'Own the architecture.',
+    short: "Use the frontier models — I do. Just understand how your system fits together so you can always move, and never build on a foundation you can't leave.",
     body: "Owning your setup does not mean running everything yourself. Use the frontier model when it is the best tool for the job; I do. What keeps you independent is understanding how your system fits together and being able to move. When a vendor changes its price or its terms, you swap the model underneath and keep working. The labs are far ahead, and building your own from scratch is slower and worse. So use them. Just do not build on a foundation you can never leave.",
   },
   {
     no: '04',
     title: 'The gate is effort, not permission.',
+    short: "No one is coming to authorize you. The barrier was never a credential — it's the hours, and those are yours to control.",
     body: "No one is coming to authorize you. The barrier was never a credential or a title. It is whether you will put in the hours to learn, and that part is yours to control. That is the good news and the hard news at once. Money and access still tilt the field, and an afternoon of practice will not change that. But the part that is genuinely yours to take has never been this large.",
   },
   {
     no: '05',
     title: 'This is the first tool an individual can own outright.',
+    short: "Every earlier productivity jump needed an institution's money to run. A capable model on hardware you already own is the first that doesn't.",
     body: "The printing press, the factory, the mainframe, the cloud. An institution captured every earlier jump in productivity, because every one of them needed an institution's money to run. A capable model on hardware you already own is the first that does not. The frontier still belongs to a few labs, and it will for a while. That is fine. Good enough and yours beats best and rented more often than the frontier wants you to believe.",
   },
 ];
@@ -52,7 +59,9 @@ export function WhatIBelieve() {
               <div className="believe__no">{b.no}</div>
               <div>
                 <h3 className="believe__title">{b.title}</h3>
-                <p className="believe__body">{b.body}</p>
+                <p className="believe__body">
+                  <Condense short={b.short}>{b.body}</Condense>
+                </p>
               </div>
             </Reveal>
           ))}
@@ -60,10 +69,16 @@ export function WhatIBelieve() {
 
         <Reveal className="believe__bridge">
           <p>
-            None of this is the point on its own. Owning the tools only matters for what you can
-            finally aim them at: your health, your family, the problems that money and access used
-            to put out of reach. Keeping your judgment valuable is the foundation.
-            <span className="coral"> Building a life worth living is the point.</span>
+            <span className="d-only">
+              None of this is the point on its own. Owning the tools only matters for what you can
+              finally aim them at: your health, your family, the problems that money and access used
+              to put out of reach. Keeping your judgment valuable is the foundation.
+              <span className="coral"> Building a life worth living is the point.</span>
+            </span>
+            <span className="m-only">
+              Owning the tools is the foundation.
+              <span className="coral"> Building a life worth living is the point.</span>
+            </span>
           </p>
         </Reveal>
       </div>

--- a/src/styles/paper.css
+++ b/src/styles/paper.css
@@ -239,23 +239,129 @@ img { display: block; max-width: 100%; }
 }
 .icon-btn:hover { color: var(--coral); border-color: var(--coral); }
 
+/* mobile menu */
+.nav__burger {
+  width: 38px; height: 38px;
+  display: inline-grid; place-items: center;
+  border: 1px solid var(--rule-strong);
+  border-radius: 1px;
+  color: var(--ink);
+  transition: color 0.2s, border-color 0.2s;
+}
+.nav__burger:hover { color: var(--coral); border-color: var(--coral); }
+@media (min-width: 900px) { .nav__burger { display: none; } }
+.nav__menu {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 49;
+  background: var(--paper);
+  border-bottom: 1px solid var(--rule-strong);
+  padding: 4.5rem var(--gutter) 1.5rem;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(-100%);
+  transition: transform 0.35s var(--ease), visibility 0.35s;
+  visibility: hidden;
+  box-shadow: 0 18px 40px rgba(34, 30, 24, 0.12);
+}
+.nav__menu[data-open="true"] { transform: translateY(0); visibility: visible; }
+.nav__menu__link {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  padding: 0.9rem 0;
+  border-top: 1px solid var(--rule);
+  display: flex; justify-content: space-between; align-items: center;
+}
+.nav__menu__link:first-of-type { border-top: none; }
+.nav__menu__link .no {
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  color: var(--ink-faint);
+  letter-spacing: 0.1em;
+}
+.nav__menu__link:active, .nav__menu__link:hover { color: var(--coral); }
+.nav__menu .btn { margin-top: 1.25rem; justify-content: center; }
+.nav__scrim {
+  position: fixed; inset: 0; z-index: 48;
+  background: rgba(34, 30, 24, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s, visibility 0.3s;
+}
+.nav__scrim[data-open="true"] { opacity: 1; visibility: visible; }
+/* never leave the mobile overlay on-screen at desktop widths (e.g. after a resize) */
+@media (min-width: 900px) {
+  .nav__menu, .nav__scrim { display: none; }
+}
+
 /* ---------------- hero / cover ---------------- */
-.cover { padding-top: clamp(6.5rem, 11vw, 9rem); padding-bottom: var(--section-y-sm); position: relative; }
+.cover {
+  position: relative;
+  min-height: clamp(560px, 88vh, 860px);
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+  border-bottom: 1px solid var(--rule);
+}
+.cover__bg {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(70% 90% at 85% 15%, rgba(192, 85, 50, 0.10), transparent 60%),
+    linear-gradient(180deg, var(--paper-2) 0%, var(--paper) 100%);
+}
+.cover__gridlines {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(var(--rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--rule) 1px, transparent 1px);
+  background-size: 80px 80px;
+  opacity: 0.7;
+  mask-image: radial-gradient(55% 55% at 22% 68%, #000 40%, transparent 100%);
+  -webkit-mask-image: radial-gradient(55% 55% at 22% 68%, #000 40%, transparent 100%);
+}
+/* portrait bleeds off the right edge. The image URL lives here (not an inline
+   style) so Vite hashes the asset and the prerender→hydrate DOM stays identical. */
+.cover__portrait {
+  position: absolute;
+  right: 0; top: 0; bottom: 0;
+  width: min(52%, 720px);
+  pointer-events: none;
+  background-image: url('../assets/headshot.jpg');
+  background-size: cover;
+  background-position: center 15%;
+  filter: grayscale(0.55) contrast(1.04) sepia(0.25);
+  mix-blend-mode: multiply;
+  opacity: 0.92;
+  mask-image: linear-gradient(270deg, #000 45%, transparent 100%);
+  -webkit-mask-image: linear-gradient(270deg, #000 45%, transparent 100%);
+}
+.cover__caption {
+  position: absolute;
+  right: var(--gutter);
+  bottom: 1.1rem;
+  z-index: 3;
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.cover__caption .coral { color: var(--coral); }
+.cover__inner {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  padding-top: clamp(6.5rem, 11vw, 9rem);
+  padding-bottom: clamp(2.5rem, 5vw, 4rem);
+}
 .cover__folio {
   display: flex; justify-content: space-between; align-items: baseline;
   gap: 1rem; flex-wrap: wrap;
   padding-bottom: 1.5rem;
   border-bottom: 1px solid var(--ink);
   margin-bottom: clamp(2rem, 4vw, 3.5rem);
-}
-.cover__grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: clamp(2rem, 5vw, 3.5rem);
-  align-items: start;
-}
-@media (min-width: 900px) {
-  .cover__grid { grid-template-columns: 1.55fr 1fr; gap: clamp(2.5rem, 5vw, 4.5rem); }
 }
 .cover__eyebrows { display: flex; flex-direction: column; gap: 0.4rem; margin-bottom: 1.5rem; }
 .cover__title {
@@ -269,8 +375,8 @@ img { display: block; max-width: 100%; }
 .cover__title em { font-style: italic; }
 .cover__title .coral { color: var(--coral); font-style: italic; }
 .cover__dek {
-  margin-top: clamp(1.75rem, 3vw, 2.5rem);
-  max-width: 48ch;
+  margin-top: clamp(1.5rem, 3vw, 2.25rem);
+  max-width: 46ch;
   font-size: var(--fs-lead);
   line-height: 1.6;
   color: var(--ink-soft);
@@ -288,48 +394,39 @@ img { display: block; max-width: 100%; }
 }
 .cover__scroll:hover { color: var(--coral); gap: 0.75rem; }
 
-/* portrait plate */
-.plate {
-  position: relative;
-  align-self: start;
+.cover__meta {
+  display: flex; gap: 2.5rem; flex-wrap: wrap;
+  margin-top: clamp(2rem, 4vw, 3rem);
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule-strong);
+  max-width: 720px;
 }
-.plate__frame {
-  position: relative;
-  border: 1px solid var(--ink);
-  padding: 0.6rem;
-  background: var(--paper-2);
-}
-.plate__img {
-  position: relative;
-  aspect-ratio: 4 / 4.4;
-  overflow: hidden;
-  background: var(--paper-3);
-}
-.plate__img img {
-  width: 100%; height: 100%;
-  object-fit: cover;
-  object-position: center 12%;
-  filter: grayscale(0.55) contrast(1.03) brightness(1.02) sepia(0.22);
-  mix-blend-mode: multiply;
-}
-.plate__img::after {
-  content: "";
-  position: absolute; inset: 0;
-  background: linear-gradient(180deg, transparent 55%, rgba(192, 85, 50, 0.14));
-  mix-blend-mode: multiply;
-  pointer-events: none;
-}
-.plate__cut {
-  display: flex; justify-content: space-between; align-items: baseline;
-  gap: 1rem;
-  margin-top: 0.75rem;
+.cover__meta > div > .k {
+  display: block;
   font-family: var(--font-mono);
   font-size: var(--fs-micro);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--ink-faint);
+  margin-bottom: 0.4rem;
 }
-.plate__cut .coral { color: var(--coral); }
+.cover__meta > div > .v {
+  font-family: var(--font-serif);
+  color: var(--ink);
+  font-size: 0.98rem;
+}
+
+@media (max-width: 719px) {
+  .cover { min-height: 0; }
+  .cover__portrait {
+    width: 100%;
+    opacity: 0.4;
+    mask-image: linear-gradient(245deg, #000 0%, transparent 70%);
+    -webkit-mask-image: linear-gradient(245deg, #000 0%, transparent 70%);
+  }
+  .cover__meta { gap: 1.25rem 2rem; }
+  .cover__caption { display: none; }
+}
 
 /* subscribe form shape */
 .subform { display: flex; gap: 0.5rem; max-width: 30rem; flex-wrap: wrap; }
@@ -354,6 +451,9 @@ img { display: block; max-width: 100%; }
   color: var(--ink-faint);
 }
 .subform__caption em { color: var(--coral); font-style: normal; }
+@media (min-width: 720px) {
+  .subform__cadence { display: block; margin-top: 0.2rem; }
+}
 
 /* ---------------- thesis (dark interlude) ---------------- */
 .thesis {
@@ -731,6 +831,41 @@ img { display: block; max-width: 100%; }
 .footer__link:hover { color: #e8a07f; }
 .footer__legal { margin-top: 2.5rem; font-family: var(--font-mono); font-size: var(--fs-micro); color: var(--faint-on-dark); letter-spacing: 0.04em; display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
 
+/* ---------------- mobile condensed copy ---------------- */
+/* .d-only: full desktop prose · .m-only: condensed mobile copy */
+.m-only { display: none; }
+@media (max-width: 719px) {
+  .d-only { display: none; }
+  .m-only { display: inline; }
+  .m-only--block { display: block; }
+}
+/* inline "More / Less" toggle revealed inside condensed mobile copy */
+.more-btn {
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--coral);
+  border-bottom: 1px solid currentColor;
+  padding-bottom: 1px;
+  margin-left: 0.4em;
+  white-space: nowrap;
+  transition: color 0.2s;
+}
+.more-btn:hover { color: var(--coral-deep); }
+.thesis .more-btn, .spec--bridge .more-btn { color: #e8a07f; }
+
+/* tighter mobile rhythm — shorter sections, snugger lists */
+@media (max-width: 719px) {
+  :root { --section-y: 3.5rem; --section-y-sm: 2.5rem; }
+  body { line-height: 1.55; }
+  .believe__item { padding: 1.6rem 0; }
+  .believe__no { font-size: 1.9rem; }
+  .believe__title { margin-bottom: 0.6rem; }
+  .cover__dek { margin-top: 1.4rem; }
+  .about__body p { margin-bottom: 1rem; }
+}
+
 /* ---------------- reveal ---------------- */
 .reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.9s var(--ease), transform 0.9s var(--ease); }
 .reveal.in { opacity: 1; transform: translateY(0); }
@@ -740,6 +875,7 @@ img { display: block; max-width: 100%; }
 .reveal-d4 { transition-delay: 0.32s; }
 
 @media (prefers-reduced-motion: reduce) {
+  * , *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
   .reveal { opacity: 1; transform: none; }
   html { scroll-behavior: auto; }
 }

--- a/src/styles/paper.css
+++ b/src/styles/paper.css
@@ -837,7 +837,6 @@ img { display: block; max-width: 100%; }
 @media (max-width: 719px) {
   .d-only { display: none; }
   .m-only { display: inline; }
-  .m-only--block { display: block; }
 }
 /* inline "More / Less" toggle revealed inside condensed mobile copy */
 .more-btn {
@@ -853,7 +852,6 @@ img { display: block; max-width: 100%; }
   transition: color 0.2s;
 }
 .more-btn:hover { color: var(--coral-deep); }
-.thesis .more-btn, .spec--bridge .more-btn { color: #e8a07f; }
 
 /* tighter mobile rhythm — shorter sections, snugger lists */
 @media (max-width: 719px) {


### PR DESCRIPTION
Targeted refinement against yesterday's "Register" single-page redesign (#15), imported from the Claude Design project, plus fixes surfaced along the way.

## UX refinements
- **Hero → full-bleed cover.** Portrait now bleeds off the right edge over subtle gridlines, with a "Fig. 1" caption and a Based / Newsletter / Focus meta bar (replaces the bordered "plate"). On mobile the portrait becomes a faded backdrop and the dek uses condensed copy.
- **Mobile navigation.** Adds a burger → slide-down menu + scrim + Escape-to-close. Mobile previously had **no** nav links at all. Also adds a **What I believe** (`#believe`) link to desktop nav + mobile menu.
- **What I Believe (mobile).** Each belief now uses a new `Condense` component — short copy + a More/Less toggle on mobile, full prose on desktop — plus a condensed closing bridge and tighter mobile rhythm.

## Fixes
- **Nav anchor scrolling.** Lenis owned the scroll position and its `requestAnimationFrame` loop was never cancelled, leaving an orphaned instance that pinned scroll to 0 — so *no* in-page link scrolled. Fixed the rAF leak and route hash clicks through `lenis.scrollTo` (lands at the section top; syncs the URL via `pushState`).
- **Hydration (React #418).** The puppeteer prerender + `hydrateRoot` pipeline breaks on adjacent text nodes (`§ {n}`, `{' '}`) — puppeteer serializes React's two text nodes as one run, so hydration mismatches. Fixed with template literals / spaces-inside-elements. Also froze `PrivacyPolicy`'s `new Date()` to a static constant.
- **Prerender per-route content.** `prerender.mjs` served `dist/index.html` as its SPA fallback, but the `/` capture overwrites it first — so `/privacy` was prerendered with the **home** page baked in. Now serves the pristine empty-`#root` shell for every route so each renders fresh.
- **`/privacy` production routing.** The CloudFront function rewrote every clean URL to `/index.html`, so `/privacy` served the home page (verified live). The function now maps clean URLs to their prerendered document (`/privacy` → `/privacy/index.html`; unknown routes 403 → SPA fallback via the existing custom-error response). `aws:setup` now **updates + publishes** an existing function (it previously skipped), and `deploy.sh` re-uploads nested route docs with no-cache and invalidates `/privacy`.

## Verification
- `tsc`, `npm run test:run`, and `npm run build` (incl. prerender) all pass.
- Prerender output: `/` = home, `/privacy` = privacy content (no home-cover leak).
- Served its own file, `/privacy/` hydrates cleanly (no `#418`, prerender matches client exactly).
- Cover, mobile menu, and What I Believe verified in-browser at desktop and phone widths.
- Hosting confirmed via AWS CLI: dewilliams.co is CloudFront `E2N5X2S9J4CDSF` + S3 `dewilliamsco-site` (not the Lightsail boxes, which host WARE/LocalMemory).

## ⚠️ Deploy note (routing change)
The `/privacy` routing fix only takes effect after **`npm run aws:setup`** (updates the live CloudFront function) followed by **`npm run deploy`**. The change is isolated to the `handler` function in `scripts/aws-setup.sh`; reverting it + re-running `aws:setup` restores prior behavior. Could not be tested locally (CloudFront), so verify `/privacy` on production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)