### PR TITLE
chore: add .claude/launch.json dev launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "autoPort": true,
+      "port": 5173
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Commits `.claude/launch.json`, a named `dev` launch target that runs `npm run dev` on port 5173 (with `autoPort` fallback). It matches the dev workflow already in use and follows the repo's convention of checking in useful `.claude` tooling (cf. `.claude/skills/deploy/SKILL.md`).

The file was previously untracked in the working tree; this just brings it under version control so the launch target is available to anyone who clones the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)