### PR TITLE
Add agent-switchboard card to Proof section

### DIFF
--- a/src/components/ProofSection.tsx
+++ b/src/components/ProofSection.tsx
@@ -40,7 +40,7 @@ const SPECS: Spec[] = [
         agent-<em>switchboard</em>
       </>
     ),
-    body: "One Telegram bot out front, several Claude Code sessions behind it — one for health, one for the family trust, one for homeschool — each a real terminal I can sit down at and take over. Started this week: my home agent grown into a switchboard I own end to end.",
+    body: "One Telegram bot out front, several Claude Code sessions behind it, one each for health, the family trust, and homeschool. Every one is a real terminal I can sit down at and take over. Started this week: my home agent grown into a switchboard I own end to end.",
   },
   {
     no: 'SP-04',

--- a/src/components/ProofSection.tsx
+++ b/src/components/ProofSection.tsx
@@ -34,7 +34,7 @@ const SPECS: Spec[] = [
   },
   {
     no: 'SP-03',
-    label: 'New · built in the open',
+    label: 'New · personal infrastructure',
     name: (
       <>
         agent-<em>switchboard</em>

--- a/src/components/ProofSection.tsx
+++ b/src/components/ProofSection.tsx
@@ -34,6 +34,16 @@ const SPECS: Spec[] = [
   },
   {
     no: 'SP-03',
+    label: 'New · built in the open',
+    name: (
+      <>
+        agent-<em>switchboard</em>
+      </>
+    ),
+    body: "One Telegram bot out front, several Claude Code sessions behind it — one for health, one for the family trust, one for homeschool — each a real terminal I can sit down at and take over. Started this week: my home agent grown into a switchboard I own end to end.",
+  },
+  {
+    no: 'SP-04',
     label: 'Built in the open',
     name: (
       <>
@@ -45,7 +55,7 @@ const SPECS: Spec[] = [
     href: 'https://github.com/danieleugenewilliams',
   },
   {
-    no: 'SP-04',
+    no: 'SP-05',
     label: 'Product · paying customers',
     name: <>WARE</>,
     body: "A workforce-automation resilience assessment. It's a real product with paying customers, and it lives at automationresilience.com.",
@@ -54,7 +64,7 @@ const SPECS: Spec[] = [
   },
   {
     bridge: true,
-    no: 'SP-05',
+    no: 'SP-06',
     label: 'Before it was mine to own',
     name: (
       <>


### PR DESCRIPTION
## Summary

Adds a dedicated card for **agent-switchboard** to the Proof section (`ProofSection.tsx`) — a personal multi-agent Telegram switchboard that routes to per-domain Claude Code sessions (health, family trust, homeschool). Started this week.

## Placement

Inserted as **SP-03**, right after "My home agents" (SP-02), since the switchboard is the infrastructure those home agents generalize into. The following cards renumber: Open source → SP-04, WARE → SP-05, the "at scale for others" bridge → SP-06.

## Link

No link for now — the repo is currently **private**, so a direct link would 404 for visitors. This matches the existing linkless SP-02 card. Once the repo is public, we can wire `github.com/danieleugenewilliams/agent-switchboard` in a follow-up.

## Testing

- `npm run build` — passes end-to-end (incl. prerender for `/` and `/privacy`).
- Confirmed the card body renders into the prerendered `dist/index.html` and cards renumber cleanly SP-01…SP-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)